### PR TITLE
Fix typo in the description

### DIFF
--- a/description.html
+++ b/description.html
@@ -7,7 +7,7 @@
 <a href="https://github.com/mapstruct/mapstruct-idea/issues">Issue Tracker</a> |
 <br/>
 <br/>
-This plugin gives some assistence in projects that use <a href="http://mapstruct.org/">MapStruct</a> to generate bean mapping code.
+This plugin gives some assistance in projects that use <a href="http://mapstruct.org/">MapStruct</a> to generate bean mapping code.
 <br/>
 <br/>
 MapStruct is a Java annotation processor for the generation of type-safe and performant mappers for Java bean classes.


### PR DESCRIPTION
There is a typo in the description of the plugin. I've corrected it.
![typo](https://user-images.githubusercontent.com/5915860/89542101-84087300-d7ff-11ea-863e-5c99e7252d93.png)
