### PR TITLE
Fixed language injection when target is field

### DIFF
--- a/change-notes.html
+++ b/change-notes.html
@@ -2,6 +2,7 @@
 <h2>1.4.0</h2>
 <ul>
     <li>Suppress redundant default parameter value assignment warning for <code>Mapping#constant</code> and <code>Mapping#defaultValue</code></li>
+    <li>Bug fix: language injections inside expressions now work when target is field</li>
 </ul>
 <h2>1.3.1</h2>
 <ul>

--- a/src/main/java/org/mapstruct/intellij/expression/JavaExpressionInjector.java
+++ b/src/main/java/org/mapstruct/intellij/expression/JavaExpressionInjector.java
@@ -27,6 +27,7 @@ import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiClassObjectAccessExpression;
 import com.intellij.psi.PsiClassType;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiJavaCodeReferenceElement;
 import com.intellij.psi.PsiLanguageInjectionHost;
 import com.intellij.psi.PsiLiteralExpression;
@@ -180,6 +181,9 @@ public class JavaExpressionInjector implements MultiHostInjector {
                             }
                             else if ( resolved instanceof PsiParameter ) {
                                 targetType = ( (PsiParameter) resolved ).getType();
+                            }
+                            else if ( resolved instanceof PsiField) {
+                                targetType = ( (PsiField) resolved ).getType();
                             }
                         }
                     }

--- a/testData/expression/dto/CarPlainDto.java
+++ b/testData/expression/dto/CarPlainDto.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.example.dto;
+
+public class CarPlainDto {
+
+    public String make;
+    public int seatCount;
+    public String manufacturingYear;
+}


### PR DESCRIPTION
Closes #95

I'm not sure if the added test is optimal here (this is just a tweaked copy of the very first test case with target and expression). The behavior was checked manually via `gradle runIde`, so I believe it's now correct.