### PR TITLE
Find disabled builder in @MapperConfig

### DIFF
--- a/src/main/java/org/mapstruct/intellij/util/TargetUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/TargetUtils.java
@@ -25,6 +25,7 @@ import com.intellij.openapi.util.Pair;
 import com.intellij.psi.PsiAnnotation;
 import com.intellij.psi.PsiAnnotationMemberValue;
 import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiClassObjectAccessExpression;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiJavaCodeReferenceElement;
 import com.intellij.psi.PsiMember;
@@ -167,6 +168,23 @@ public class TargetUtils {
                 if ( builderValue instanceof PsiAnnotation ) {
                     Boolean disableBuilder = getBooleanAttributeValue( (PsiAnnotation) builderValue, "disableBuilder" );
                     return Optional.ofNullable( disableBuilder );
+                }
+            }
+            else {
+                PsiNameValuePair configAttribute =
+                        AnnotationUtil.findDeclaredAttribute( requestedAnnotation, "config" );
+                if ( configAttribute != null ) {
+                    PsiAnnotationMemberValue configValue = configAttribute.getValue();
+
+                    if ( configValue != null ) {
+                        PsiJavaCodeReferenceElement referenceElement =
+                                ((PsiClassObjectAccessExpression) configValue).getOperand()
+                                        .getInnermostComponentReferenceElement();
+                        if (referenceElement != null) {
+                            return findDisableBuilder( (PsiModifierListOwner) referenceElement.resolve(),
+                                    "org.mapstruct.MapperConfig" );
+                        }
+                    }
                 }
             }
         }

--- a/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesWithBuilderInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesWithBuilderInspectionTest.java
@@ -51,7 +51,10 @@ public class UnmappedTargetPropertiesWithBuilderInspectionTest extends BaseInspe
                 "Add unmapped target property: 'targetTestName'",
 
                 "Ignore unmapped target property: 'builderTestName'",
-                "Add unmapped target property: 'builderTestName'"
+                "Add unmapped target property: 'builderTestName'",
+
+                "Ignore unmapped target property: 'targetTestName'",
+                "Add unmapped target property: 'targetTestName'"
             );
 
         allQuickFixes.forEach( myFixture::launchAction );

--- a/testData/inspection/UnmappedTargetPropertiesWithBuilder.java
+++ b/testData/inspection/UnmappedTargetPropertiesWithBuilder.java
@@ -7,6 +7,7 @@
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
+import org.mapstruct.MapperConfig;
 import org.mapstruct.Mapping;
 import org.example.data.UnmappedTargetPropertiesData.Target;
 
@@ -34,4 +35,15 @@ interface MapperDisabledBuilderBeanMappingEnabledBuilder {
 
     @BeanMapping(builder = @Builder(disableBuilder = false))
     Target <warning descr="Unmapped target property: builderTestName">map</warning>(String source);
+}
+
+@MapperConfig(builder = @Builder(disableBuilder = true))
+class DoNotUseBuilderMapperConfig {
+
+}
+
+@Mapper(config = DoNotUseBuilderMapperConfig.class)
+interface MapperConfigDisabledBuilder {
+
+    Target <warning descr="Unmapped target property: targetTestName">map</warning>(String source);
 }

--- a/testData/inspection/UnmappedTargetPropertiesWithBuilder_after.java
+++ b/testData/inspection/UnmappedTargetPropertiesWithBuilder_after.java
@@ -7,6 +7,7 @@
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
+import org.mapstruct.MapperConfig;
 import org.mapstruct.Mapping;
 import org.example.data.UnmappedTargetPropertiesData.Target;
 
@@ -41,5 +42,18 @@ interface MapperDisabledBuilderBeanMappingEnabledBuilder {
     @Mapping(target = "builderTestName", source = "")
     @Mapping(target = "builderTestName", ignore = true)
     @BeanMapping(builder = @Builder(disableBuilder = false))
+    Target map(String source);
+}
+
+@MapperConfig(builder = @Builder(disableBuilder = true))
+class DoNotUseBuilderMapperConfig {
+
+}
+
+@Mapper(config = DoNotUseBuilderMapperConfig.class)
+interface MapperConfigDisabledBuilder {
+
+    @Mapping(target = "targetTestName", source = "")
+    @Mapping(target = "targetTestName", ignore = true)
     Target map(String source);
 }


### PR DESCRIPTION
Thank you for your hard work. 👍 

The actual implementation show the quickfix for builder fields when the builders are disabled in an external `@MapperConfig`. This PR handles that case.