### PR TITLE
remove redundant if from UnmappedTargetPropertiesInspection

### DIFF
--- a/src/main/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspection.java
@@ -174,11 +174,7 @@ public class UnmappedTargetPropertiesInspection extends InspectionBase {
                 || !( isMapper( containingClass ) || isMapperConfig( containingClass ) ) ) {
                 return null;
             }
-            PsiType targetType = TargetUtils.getRelevantType( method );
-            if ( targetType == null ) {
-                return null;
-            }
-            return targetType;
+            return TargetUtils.getRelevantType( method );
         }
     }
 


### PR DESCRIPTION
Currently there is no need to check for `null` and then return `null`. So I removed the redundant check and directly returned the value.