### PR TITLE
Set caret position to empty source attribute after quick fix

### DIFF
--- a/src/main/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspection.java
@@ -185,15 +185,18 @@ public class UnmappedTargetPropertiesInspection extends InspectionBase {
         private final String myText;
         private final String myFamilyName;
         private final Supplier<Collection<PsiAnnotation>> myAnnotationSupplier;
+        private final boolean myMoveCaretToEmptySourceAttribute;
 
         private UnmappedTargetPropertyFix(@NotNull PsiMethod modifierListOwner,
             @NotNull String text,
             @NotNull String familyName,
-            @NotNull Supplier<Collection<PsiAnnotation>> annotationSupplier) {
+            @NotNull Supplier<Collection<PsiAnnotation>> annotationSupplier,
+            boolean moveCaretToEmptySourceAttribute) {
             super( modifierListOwner );
             myText = text;
             myFamilyName = familyName;
             myAnnotationSupplier = annotationSupplier;
+            myMoveCaretToEmptySourceAttribute = moveCaretToEmptySourceAttribute;
         }
 
         @NotNull
@@ -232,7 +235,7 @@ public class UnmappedTargetPropertiesInspection extends InspectionBase {
             PsiMethod mappingMethod = (PsiMethod) startElement;
 
             for ( PsiAnnotation annotation : myAnnotationSupplier.get() ) {
-                addMappingAnnotation( project, mappingMethod, annotation );
+                addMappingAnnotation( project, mappingMethod, annotation, myMoveCaretToEmptySourceAttribute );
             }
         }
 
@@ -272,7 +275,8 @@ public class UnmappedTargetPropertiesInspection extends InspectionBase {
             method,
             message,
             MapStructBundle.message( "intention.add.unmapped.target.property" ),
-            new UnmappedTargetPropertyFixAnnotationSupplier( method, target )
+            new UnmappedTargetPropertyFixAnnotationSupplier( method, target ),
+            true
         );
     }
 
@@ -296,7 +300,8 @@ public class UnmappedTargetPropertiesInspection extends InspectionBase {
             method,
             message,
             MapStructBundle.message( "intention.add.ignore.unmapped.target.property" ),
-            annotationSupplier
+            annotationSupplier,
+            false
         );
     }
 
@@ -328,7 +333,8 @@ public class UnmappedTargetPropertiesInspection extends InspectionBase {
             method,
             message,
             MapStructBundle.message( "intention.add.ignore.all.unmapped.target.properties" ),
-            annotationSupplier
+            annotationSupplier,
+            false
         );
     }
 

--- a/src/main/java/org/mapstruct/intellij/util/MapstructAnnotationUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructAnnotationUtils.java
@@ -69,8 +69,9 @@ public class MapstructAnnotationUtils {
      * @param mappingAnnotation the {@link org.mapstruct.Mapping} annotation
      */
     public static void addMappingAnnotation(@NotNull Project project,
-        @NotNull PsiMethod mappingMethod,
-        @NotNull PsiAnnotation mappingAnnotation) {
+                                            @NotNull PsiMethod mappingMethod,
+                                            @NotNull PsiAnnotation mappingAnnotation,
+                                            boolean moveCaretToEmptySourceAttribute) {
         Pair<PsiAnnotation, Optional<PsiAnnotation>> mappingsPair = findOrCreateMappingsAnnotation(
             project,
             mappingMethod
@@ -90,7 +91,10 @@ public class MapstructAnnotationUtils {
                     project,
                     () -> {
                         PsiElement replaced = containerAnnotation.replace( newAnnotation );
-                        moveCaretToEmptySourceAttribute( project, replaced );
+
+                        if ( moveCaretToEmptySourceAttribute ) {
+                            moveCaretToEmptySourceAttribute( project, replaced );
+                        }
                     },
                     containingFile
                 );
@@ -119,7 +123,9 @@ public class MapstructAnnotationUtils {
                         );
                         JavaCodeStyleManager.getInstance( project ).shortenClassReferences( inserted );
 
-                        moveCaretToEmptySourceAttribute( project, inserted );
+                        if ( moveCaretToEmptySourceAttribute ) {
+                            moveCaretToEmptySourceAttribute( project, inserted );
+                        }
 
                     }, containingFile );
 

--- a/src/test/java/org/mapstruct/intellij/inspection/BaseInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/BaseInspectionTest.java
@@ -29,7 +29,11 @@ public abstract class BaseInspectionTest extends MapstructBaseCompletionTestCase
 
     protected void doTest() {
         String testName = getTestName( false );
-        configureByFile( testName + ".java" );
+        doTest( testName + ".java" );
+    }
+
+    protected void doTest(String path) {
+        configureByFile( path );
         myFixture.enableInspections( getInspection() );
         // Disable info checks as there is a difference between 2018.x and 2019.x
         // Links in 2019.x have an info highlighting

--- a/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspectionCaretAfterQuickfixTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspectionCaretAfterQuickfixTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.intellij.inspection;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.openapi.editor.Caret;
+import org.jetbrains.annotations.NotNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Oliver Erhart
+ */
+public class UnmappedTargetPropertiesInspectionCaretAfterQuickfixTest extends BaseInspectionTest {
+
+    @NotNull
+    @Override
+    protected Class<UnmappedTargetPropertiesInspection> getInspection() {
+        return UnmappedTargetPropertiesInspection.class;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        myFixture.copyFileToProject(
+            "UnmappedTargetPropertiesData.java",
+            "org/example/data/UnmappedTargetPropertiesData.java"
+        );
+    }
+
+    public void testUnmappedTargetPropertiesJdk8() {
+        doTest();
+        List<IntentionAction> addMissingTargetQuickfixes = myFixture.getAllQuickFixes()
+            .stream()
+            .filter( i -> i.getText().startsWith( "Add unmapped target property " ) )
+            .collect( Collectors.toList() );
+
+        addMissingTargetQuickfixes.forEach( this::launchAndAssertCaretPosition );
+    }
+
+    private void launchAndAssertCaretPosition(IntentionAction addMissingTargetQuickFix) {
+
+        myFixture.launchAction( addMissingTargetQuickFix );
+
+        assertThatCaretIsInsideOfSourceString();
+    }
+
+    private void assertThatCaretIsInsideOfSourceString() {
+        assertThat( lineContentBeforeSelection() ).endsWith( "source = \"" );
+    }
+
+    private CharSequence lineContentBeforeSelection() {
+
+        Caret currentCaret = myFixture.getEditor().getCaretModel().getCurrentCaret();
+
+        return myFixture.getEditor()
+            .getDocument()
+            .getCharsSequence()
+            .subSequence( currentCaret.getVisualLineStart(), currentCaret.getSelectionEnd() );
+    }
+}

--- a/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspectionCaretAfterQuickfixTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspectionCaretAfterQuickfixTest.java
@@ -34,21 +34,55 @@ public class UnmappedTargetPropertiesInspectionCaretAfterQuickfixTest extends Ba
         );
     }
 
-    public void testUnmappedTargetPropertiesJdk8() {
-        doTest();
+    public void testAddUnmappedTargetProperties() {
+        doTest( "UnmappedTargetPropertiesJdk8.java" );
+
         List<IntentionAction> addMissingTargetQuickfixes = myFixture.getAllQuickFixes()
             .stream()
             .filter( i -> i.getText().startsWith( "Add unmapped target property " ) )
             .collect( Collectors.toList() );
 
-        addMissingTargetQuickfixes.forEach( this::launchAndAssertCaretPosition );
+        addMissingTargetQuickfixes.forEach( this::launchAndAssertCaretPositionInSource );
     }
 
-    private void launchAndAssertCaretPosition(IntentionAction addMissingTargetQuickFix) {
+    public void testIgnoreUnmappedTargetProperties() {
+        doTest( "UnmappedTargetPropertiesJdk8.java" );
 
-        myFixture.launchAction( addMissingTargetQuickFix );
+        List<IntentionAction> addMissingTargetQuickfixes = myFixture.getAllQuickFixes()
+            .stream()
+            .filter( i -> i.getText().startsWith( "Ignore unmapped target property" ) )
+            .collect( Collectors.toList() );
+
+        addMissingTargetQuickfixes.forEach( this::launchAndAssertUnchangedCaretPosition );
+    }
+
+    public void testIgnoreAllUnmappedTargetProperties() {
+        doTest( "UnmappedTargetPropertiesJdk8.java" );
+
+        List<IntentionAction> addMissingTargetQuickfixes = myFixture.getAllQuickFixes()
+            .stream()
+            .filter( i -> i.getText().startsWith( "Ignore all unmapped target properties" ) )
+            .collect( Collectors.toList() );
+
+        addMissingTargetQuickfixes.forEach( this::launchAndAssertUnchangedCaretPosition );
+    }
+
+    private void launchAndAssertCaretPositionInSource(IntentionAction quickFix) {
+
+        myFixture.launchAction( quickFix );
 
         assertThatCaretIsInsideOfSourceString();
+    }
+
+    private void launchAndAssertUnchangedCaretPosition(IntentionAction quickFix) {
+
+        Caret caretBefore = myFixture.getEditor().getCaretModel().getCurrentCaret();
+
+        myFixture.launchAction( quickFix );
+
+        Caret caretAfter = myFixture.getEditor().getCaretModel().getCurrentCaret();
+
+        assertThat( caretAfter ).isEqualTo( caretBefore );
     }
 
     private void assertThatCaretIsInsideOfSourceString() {

--- a/testData/inspection/UnmappedTargetPropertiesJdk8.java
+++ b/testData/inspection/UnmappedTargetPropertiesJdk8.java
@@ -78,7 +78,7 @@ interface DefaultMapper {
 }
 
 @Mapper
-abstract class AbstrctMapperWithoutAbstractMethod {
+abstract class AbstractMapperWithoutAbstractMethod {
 
     protected Target map(Source source) {
         return null;

--- a/testData/inspection/UnmappedTargetPropertiesJdk8_after.java
+++ b/testData/inspection/UnmappedTargetPropertiesJdk8_after.java
@@ -92,7 +92,7 @@ interface DefaultMapper {
 }
 
 @Mapper
-abstract class AbstrctMapperWithoutAbstractMethod {
+abstract class AbstractMapperWithoutAbstractMethod {
 
     protected Target map(Source source) {
         return null;


### PR DESCRIPTION
This PR fixes #28.

The test handles the case with and without surrounding `@Mappings({...})` annotation.