### PR TITLE
fix wrong unmapped target warning with Mapping annotation

### DIFF
--- a/src/main/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspection.java
@@ -86,7 +86,8 @@ public class UnmappedTargetPropertiesInspection extends InspectionBase {
 
             // find and remove all defined mapping targets
             Set<String> definedTargets = TargetUtils.findAllDefinedMappingTargets( method, mapStructVersion )
-                .collect( Collectors.toSet() );
+                    .map( MyJavaElementVisitor::getBaseTarget )
+                    .collect( Collectors.toSet() );
             allTargetProperties.removeAll( definedTargets );
 
             if ( definedTargets.contains( "." ) ) {
@@ -139,6 +140,15 @@ public class UnmappedTargetPropertiesInspection extends InspectionBase {
                     quickFixes.toArray( UnmappedTargetPropertyFix.EMPTY_ARRAY )
                 );
             }
+        }
+
+        @NotNull
+        private static String getBaseTarget(@NotNull String target) {
+            int dotIndex = target.indexOf( "." );
+            if ( dotIndex > 0 ) {
+                return target.substring( 0, dotIndex );
+            }
+            return target;
         }
 
         private static boolean isBeanMappingIgnoreByDefault(PsiMethod method) {

--- a/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesSubObjectMappingTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesSubObjectMappingTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.intellij.inspection;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author hduelme
+ */
+public class UnmappedTargetPropertiesSubObjectMappingTest extends BaseInspectionTest {
+
+    @NotNull
+    @Override
+    protected Class<UnmappedTargetPropertiesInspection> getInspection() {
+        return UnmappedTargetPropertiesInspection.class;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        myFixture.copyFileToProject(
+            "UnmappedTargetPropertiesData.java",
+            "org/example/data/UnmappedTargetPropertiesData.java"
+        );
+    }
+
+    public void testUnmappedTargetPropertiesSubObjectMapping() {
+        doTest();
+        List<IntentionAction> allQuickFixes = myFixture.getAllQuickFixes();
+
+        assertThat( allQuickFixes )
+            .isEmpty();
+    }
+}

--- a/testData/inspection/UnmappedTargetPropertiesData.java
+++ b/testData/inspection/UnmappedTargetPropertiesData.java
@@ -79,4 +79,16 @@ public class UnmappedTargetPropertiesData {
         }
     }
 
+    public static class TargetWithInnerObject {
+        private Target testTarget;
+
+        public Target getTestTarget() {
+            return testTarget;
+        }
+
+        public void setTestTarget(Target testTarget) {
+            this.testTarget = testTarget;
+        }
+    }
+
 }

--- a/testData/inspection/UnmappedTargetPropertiesSubObjectMapping.java
+++ b/testData/inspection/UnmappedTargetPropertiesSubObjectMapping.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Mappings;
+import org.example.data.UnmappedTargetPropertiesData.TargetWithInnerObject;
+import org.example.data.UnmappedTargetPropertiesData.Source;
+
+@Mapper
+interface SingleMappingsMapper {
+
+    @Mappings({
+            @Mapping(target = "testTarget.moreTarget", source = "moreSource")
+    })
+    TargetWithInnerObject map(Source source);
+}
+
+@Mapper
+interface SingleMappingMapper {
+
+    @Mapping(target = "testTarget.testName", source = "name")
+    TargetWithInnerObject map(Source source);
+}
+
+@Mapper
+interface UpdateMapper {
+
+    @Mapping(target = "testTarget.moreTarget", source = "moreSource")
+    void update(@MappingTarget TargetWithInnerObject target, Source source);
+}


### PR DESCRIPTION
Currently the plugin gives a warning if an field is mapped with `@Mapping` where the target contains a dot.

This fixes the issue, by splitting the target on the dot and only removing the first part from `allTargetProperties`.

I also wrote a small test covering this issue.