### PR TITLE
#65 support inherit configuration

### DIFF
--- a/src/main/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspection.java
@@ -44,9 +44,11 @@ import static org.mapstruct.intellij.util.MapstructUtil.isInheritInverseConfigur
 import static org.mapstruct.intellij.util.MapstructUtil.isMapper;
 import static org.mapstruct.intellij.util.MapstructUtil.isMapperConfig;
 import static org.mapstruct.intellij.util.SourceUtils.findAllSourceProperties;
-import static org.mapstruct.intellij.util.TargetUtils.*;
+import static org.mapstruct.intellij.util.TargetUtils.findAllDefinedMappingTargets;
 import static org.mapstruct.intellij.util.TargetUtils.findAllSourcePropertiesForCurrentTarget;
 import static org.mapstruct.intellij.util.TargetUtils.findAllTargetProperties;
+import static org.mapstruct.intellij.util.TargetUtils.findInheritedTargetProperties;
+import static org.mapstruct.intellij.util.TargetUtils.getRelevantType;
 
 /**
  * Inspection that checks if there are unmapped target properties.
@@ -86,8 +88,8 @@ public class UnmappedTargetPropertiesInspection extends InspectionBase {
 
             // find and remove all defined mapping targets
             Set<String> definedTargets = findAllDefinedMappingTargets( method, mapStructVersion )
-                    .map( MyJavaElementVisitor::getBaseTarget )
-                    .collect( Collectors.toSet() );
+                .map( MyJavaElementVisitor::getBaseTarget )
+                .collect( Collectors.toSet() );
             allTargetProperties.removeAll( definedTargets );
 
             // find and remove all inherited target properties

--- a/src/main/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspection.java
@@ -36,7 +36,6 @@ import org.mapstruct.intellij.MapStructBundle;
 import org.mapstruct.intellij.settings.ProjectSettings;
 import org.mapstruct.intellij.util.MapStructVersion;
 import org.mapstruct.intellij.util.MapstructUtil;
-import org.mapstruct.intellij.util.TargetUtils;
 
 import static com.intellij.codeInsight.AnnotationUtil.findAnnotation;
 import static com.intellij.codeInsight.AnnotationUtil.getBooleanAttributeValue;
@@ -45,6 +44,7 @@ import static org.mapstruct.intellij.util.MapstructUtil.isInheritInverseConfigur
 import static org.mapstruct.intellij.util.MapstructUtil.isMapper;
 import static org.mapstruct.intellij.util.MapstructUtil.isMapperConfig;
 import static org.mapstruct.intellij.util.SourceUtils.findAllSourceProperties;
+import static org.mapstruct.intellij.util.TargetUtils.*;
 import static org.mapstruct.intellij.util.TargetUtils.findAllSourcePropertiesForCurrentTarget;
 import static org.mapstruct.intellij.util.TargetUtils.findAllTargetProperties;
 
@@ -85,10 +85,16 @@ public class UnmappedTargetPropertiesInspection extends InspectionBase {
             Set<String> allTargetProperties = findAllTargetProperties( targetType, mapStructVersion, method );
 
             // find and remove all defined mapping targets
-            Set<String> definedTargets = TargetUtils.findAllDefinedMappingTargets( method, mapStructVersion )
+            Set<String> definedTargets = findAllDefinedMappingTargets( method, mapStructVersion )
                     .map( MyJavaElementVisitor::getBaseTarget )
                     .collect( Collectors.toSet() );
             allTargetProperties.removeAll( definedTargets );
+
+            // find and remove all inherited target properties
+            Set<String> inheritedTargetProperties = findInheritedTargetProperties( method, mapStructVersion )
+                .map( MyJavaElementVisitor::getBaseTarget )
+                .collect( Collectors.toSet() );
+            allTargetProperties.removeAll( inheritedTargetProperties );
 
             if ( definedTargets.contains( "." ) ) {
                 // If there is a defined current target then we need to remove all implicit mapped properties for
@@ -184,7 +190,7 @@ public class UnmappedTargetPropertiesInspection extends InspectionBase {
                 || !( isMapper( containingClass ) || isMapperConfig( containingClass ) ) ) {
                 return null;
             }
-            return TargetUtils.getRelevantType( method );
+            return getRelevantType( method );
         }
     }
 

--- a/src/main/java/org/mapstruct/intellij/util/InheritConfigurationUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/InheritConfigurationUtils.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.intellij.util;
 
 import java.util.ArrayList;
@@ -28,6 +33,9 @@ import static org.mapstruct.intellij.util.MapstructUtil.isMappingTarget;
  * Utils for working with inherited configurations based on {@link org.mapstruct.InheritConfiguration}
  */
 public class InheritConfigurationUtils {
+
+    private InheritConfigurationUtils() {
+    }
 
     /**
      * Find all mapping methods (regardless of their type and parameter) that are in the scope to be inherited from:
@@ -86,15 +94,16 @@ public class InheritConfigurationUtils {
      * @param inheritConfigurationAnnotation the {@link org.mapstruct.InheritConfiguration} annotation
      * @return a mapping method to inherit from, only if it is the only possible one found.
      */
-    public static Optional<PsiMethod> findInheritMappingMethod(@NotNull PsiMethod mappingMethod,
-                                                               @NotNull Stream<PsiMethod> candidates,
-                                                               @NotNull PsiAnnotation inheritConfigurationAnnotation) {
+    public static Optional<PsiMethod> findSingleMatchingInheritMappingMethod(
+        @NotNull PsiMethod mappingMethod,
+        @NotNull Stream<PsiMethod> candidates,
+        @NotNull PsiAnnotation inheritConfigurationAnnotation) {
 
         String inheritConfigurationName = getStringAttributeValue( inheritConfigurationAnnotation, "name" );
 
         List<PsiMethod> matchingCandidates = candidates
             .filter( candidate -> isNotTheSameMethod( mappingMethod, candidate ) )
-            .filter( candidate -> matchesNameWhenSet( inheritConfigurationName, candidate ) )
+            .filter( candidate -> matchesNameWhenNameIsDefined( inheritConfigurationName, candidate ) )
             .filter( candidate -> canInheritFrom( mappingMethod, candidate ) )
             .collect( Collectors.toList() );
 
@@ -110,7 +119,7 @@ public class InheritConfigurationUtils {
         return !( mappingMethod.equals( candidate ) );
     }
 
-    private static boolean matchesNameWhenSet(String inheritConfigurationName, PsiMethod candidate) {
+    private static boolean matchesNameWhenNameIsDefined(String inheritConfigurationName, PsiMethod candidate) {
 
         if ( inheritConfigurationName == null || inheritConfigurationName.isEmpty() ) {
             return true;
@@ -120,7 +129,7 @@ public class InheritConfigurationUtils {
     }
 
     /**
-     * simplified version of org.mapstruct.ap.internal.model.source.SourceMethod#canInheritFrom
+     * simplified version of <code>org.mapstruct.ap.internal.model.source.SourceMethod#canInheritFrom</code>
      */
     public static boolean canInheritFrom(PsiMethod mappingMethod, PsiMethod candidate) {
 
@@ -166,7 +175,7 @@ public class InheritConfigurationUtils {
     }
 
     /**
-     * this is a psi-modified copy of org.mapstruct.ap.internal.model.source.SourceMethod#allParametersAreAssignable
+     * psi-modified copy of <code>org.mapstruct.ap.internal.model.source.SourceMethod#allParametersAreAssignable</code>
      */
     private static boolean allParametersAreAssignable(List<PsiParameter> fromParams, List<PsiParameter> toParams) {
         if ( fromParams.size() == toParams.size() ) {

--- a/src/main/java/org/mapstruct/intellij/util/InheritConfigurationUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/InheritConfigurationUtils.java
@@ -1,0 +1,195 @@
+package org.mapstruct.intellij.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiModifierListOwner;
+import com.intellij.psi.PsiParameter;
+import com.intellij.psi.PsiParameterList;
+import com.intellij.psi.PsiType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static com.intellij.codeInsight.AnnotationUtil.getStringAttributeValue;
+import static org.mapstruct.intellij.util.MapstructAnnotationUtils.findMapperConfigReference;
+import static org.mapstruct.intellij.util.MapstructAnnotationUtils.findReferencedMapperClasses;
+import static org.mapstruct.intellij.util.MapstructUtil.isMappingTarget;
+
+/**
+ * Utils for working with inherited configurations based on {@link org.mapstruct.InheritConfiguration}
+ */
+public class InheritConfigurationUtils {
+
+    /**
+     * Find all mapping methods (regardless of their type and parameter) that are in the scope to be inherited from:
+     * <ul>
+     *     <li>local methods</li>
+     *     <li>methods of mappers extending from</li>
+     *     <li>methods in referenced mappers by {@link org.mapstruct.Mapper#uses()}</li>
+     *     <li>methods from {@link org.mapstruct.MapperConfig}</li>
+     *     <li>methods from referenced mappers from {@link org.mapstruct.MapperConfig#uses()}</li>
+     * </ul>
+     *
+     * @param containingClass containing class of the mapping method to check
+     * @param mapperAnnotation the mapper annotation of the containing class
+     * @return possible mapping methods to be inherited from
+     */
+    public static Stream<PsiMethod> findMappingMethodsFromInheritScope(@NotNull PsiClass containingClass,
+                                                                       @NotNull PsiAnnotation mapperAnnotation) {
+
+        Stream<PsiMethod> localAndParentMethods = findLocalAndParentMethods( containingClass ).stream();
+
+        Stream<PsiMethod> referencedMethods = findReferencedMapperClasses( mapperAnnotation )
+            .flatMap( c -> Arrays.stream( c.getMethods() ) );
+
+        Stream<PsiMethod> mapperConfigMethods = findMapperConfigMethods( mapperAnnotation );
+
+        return Stream.concat( Stream.concat( localAndParentMethods, referencedMethods ), mapperConfigMethods );
+    }
+
+    private static List<PsiMethod> findLocalAndParentMethods(PsiClass containingClass) {
+
+        List<PsiMethod> result = new ArrayList<>( List.of( containingClass.getMethods() ) );
+
+        for ( PsiClass anInterface : containingClass.getInterfaces() ) {
+            result.addAll( findLocalAndParentMethods( anInterface ) );
+        }
+
+        return result;
+    }
+
+    private static Stream<PsiMethod> findMapperConfigMethods(@NotNull PsiAnnotation mapperAnnotation) {
+
+        PsiModifierListOwner mapperConfigReference = findMapperConfigReference( mapperAnnotation );
+
+        if ( !( mapperConfigReference instanceof PsiClass ) ) {
+            return Stream.empty();
+        }
+
+        return Arrays.stream( ( (PsiClass) mapperConfigReference ).getMethods() );
+    }
+
+    /**
+     * Find a candidate that this mapping method can inherit from, only if it is the only one possible.
+     *
+     * @param mappingMethod the mapping method to find a belonging method
+     * @param candidates mapping methods that possibly hold the method to inherit from
+     * @param inheritConfigurationAnnotation the {@link org.mapstruct.InheritConfiguration} annotation
+     * @return a mapping method to inherit from, only if it is the only possible one found.
+     */
+    public static Optional<PsiMethod> findInheritMappingMethod(@NotNull PsiMethod mappingMethod,
+                                                               @NotNull Stream<PsiMethod> candidates,
+                                                               @NotNull PsiAnnotation inheritConfigurationAnnotation) {
+
+        String inheritConfigurationName = getStringAttributeValue( inheritConfigurationAnnotation, "name" );
+
+        List<PsiMethod> matchingCandidates = candidates
+            .filter( candidate -> isNotTheSameMethod( mappingMethod, candidate ) )
+            .filter( candidate -> matchesNameWhenSet( inheritConfigurationName, candidate ) )
+            .filter( candidate -> canInheritFrom( mappingMethod, candidate ) )
+            .collect( Collectors.toList() );
+
+        if ( matchingCandidates.size() != 1 ) {
+            return Optional.empty();
+        }
+
+        return matchingCandidates.stream().findFirst();
+    }
+
+    private static boolean isNotTheSameMethod(PsiMethod mappingMethod, PsiMethod candidate) {
+
+        return !( mappingMethod.equals( candidate ) );
+    }
+
+    private static boolean matchesNameWhenSet(String inheritConfigurationName, PsiMethod candidate) {
+
+        if ( inheritConfigurationName == null || inheritConfigurationName.isEmpty() ) {
+            return true;
+        }
+
+        return candidate.getName().equals( inheritConfigurationName );
+    }
+
+    /**
+     * simplified version of org.mapstruct.ap.internal.model.source.SourceMethod#canInheritFrom
+     */
+    public static boolean canInheritFrom(PsiMethod mappingMethod, PsiMethod candidate) {
+
+        PsiType targetType = findTargetTypeOfMappingMethod( mappingMethod );
+
+        return targetType != null &&
+            candidate.getBody() == null &&
+            candidate.getReturnType() != null && candidate.getReturnType().isAssignableFrom( targetType )
+            && allParametersAreAssignable( mappingMethod.getParameterList(), candidate.getParameterList() );
+    }
+
+    @Nullable
+    private static PsiType findTargetTypeOfMappingMethod(PsiMethod mappingMethod) {
+
+        PsiType targetType = mappingMethod.getReturnType();
+
+        if ( !PsiType.VOID.equals( targetType ) ) {
+            return targetType;
+        }
+
+        return Stream.of( mappingMethod.getParameterList().getParameters() )
+            .filter( MapstructUtil::isMappingTarget )
+            .findFirst()
+            .map( PsiParameter::getType )
+            .orElse( null );
+    }
+
+    private static boolean allParametersAreAssignable(PsiParameterList inheritParameters,
+                                                      PsiParameterList candidateParameters) {
+
+        if ( inheritParameters == null || candidateParameters == null || inheritParameters.isEmpty() ||
+            candidateParameters.isEmpty() ) {
+            return false;
+        }
+
+        List<PsiParameter> fromParams = Arrays.stream( inheritParameters.getParameters() )
+            .filter( p -> !isMappingTarget( p ) )
+            .collect( Collectors.toList() );
+
+        List<PsiParameter> toParams = Arrays.asList( candidateParameters.getParameters() );
+
+        return allParametersAreAssignable( fromParams, toParams );
+    }
+
+    /**
+     * this is a psi-modified copy of org.mapstruct.ap.internal.model.source.SourceMethod#allParametersAreAssignable
+     */
+    private static boolean allParametersAreAssignable(List<PsiParameter> fromParams, List<PsiParameter> toParams) {
+        if ( fromParams.size() == toParams.size() ) {
+            Set<PsiParameter> unaccountedToParams = new HashSet<>( toParams );
+
+            for ( PsiParameter fromParam : fromParams ) {
+                // each fromParam needs at least one match, and all toParam need to be accounted for at the end
+                boolean hasMatch = false;
+                for ( PsiParameter toParam : toParams ) {
+                    if ( toParam.getType().isAssignableFrom( fromParam.getType() ) ) {
+                        unaccountedToParams.remove( toParam );
+                        hasMatch = true;
+                    }
+                }
+
+                if ( !hasMatch ) {
+                    return false;
+                }
+            }
+
+            return unaccountedToParams.isEmpty();
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
@@ -90,6 +90,8 @@ public final class MapstructUtil {
 
     public static final String NAMED_ANNOTATION_FQN = Named.class.getName();
 
+    public static final String INHERIT_CONFIGURATION_FQN = InheritConfiguration.class.getName();
+
     static final String MAPPINGS_ANNOTATION_FQN = Mappings.class.getName();
     static final String VALUE_MAPPING_ANNOTATION_FQN = ValueMapping.class.getName();
     static final String VALUE_MAPPINGS_ANNOTATION_FQN = ValueMappings.class.getName();

--- a/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
@@ -49,6 +49,10 @@ import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mapstruct.BeanMapping;
+import org.mapstruct.Builder;
+import org.mapstruct.Context;
+import org.mapstruct.EnumMapping;
+import org.mapstruct.InheritConfiguration;
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.MapperConfig;
@@ -90,11 +94,10 @@ public final class MapstructUtil {
     static final String VALUE_MAPPING_ANNOTATION_FQN = ValueMapping.class.getName();
     static final String VALUE_MAPPINGS_ANNOTATION_FQN = ValueMappings.class.getName();
     private static final String MAPPING_TARGET_ANNOTATION_FQN = MappingTarget.class.getName();
-    //TODO maybe we need to include the 1.2.0-RC1 here
-    private static final String CONTEXT_ANNOTATION_FQN = "org.mapstruct.Context";
-    private static final String INHERIT_INVERSE_CONFIGURATION = InheritInverseConfiguration.class.getName();
-    private static final String BUILDER_ANNOTATION_FQN = "org.mapstruct.Builder";
-    private static final String ENUM_MAPPING_ANNOTATION_FQN = "org.mapstruct.EnumMapping";
+    private static final String CONTEXT_ANNOTATION_FQN = Context.class.getName();
+    private static final String INHERIT_INVERSE_CONFIGURATION_FQN = InheritInverseConfiguration.class.getName();
+    private static final String BUILDER_ANNOTATION_FQN = Builder.class.getName();
+    private static final String ENUM_MAPPING_ANNOTATION_FQN = EnumMapping.class.getName();
 
     /**
      * Hide constructor.
@@ -569,7 +572,7 @@ public final class MapstructUtil {
      * {@code false} otherwise
      */
     public static boolean isInheritInverseConfiguration(PsiMethod method) {
-        return isAnnotated( method, INHERIT_INVERSE_CONFIGURATION, AnnotationUtil.CHECK_TYPE );
+        return isAnnotated( method, INHERIT_INVERSE_CONFIGURATION_FQN, AnnotationUtil.CHECK_TYPE );
     }
 
 }

--- a/src/main/java/org/mapstruct/intellij/util/TargetUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/TargetUtils.java
@@ -42,7 +42,8 @@ import org.jetbrains.annotations.Nullable;
 import static com.intellij.codeInsight.AnnotationUtil.findAnnotation;
 import static com.intellij.codeInsight.AnnotationUtil.findDeclaredAttribute;
 import static com.intellij.codeInsight.AnnotationUtil.getBooleanAttributeValue;
-import static org.mapstruct.intellij.util.InheritConfigurationUtils.*;
+import static org.mapstruct.intellij.util.InheritConfigurationUtils.findMappingMethodsFromInheritScope;
+import static org.mapstruct.intellij.util.InheritConfigurationUtils.findSingleMatchingInheritMappingMethod;
 import static org.mapstruct.intellij.util.MapstructAnnotationUtils.findAllDefinedMappingAnnotations;
 import static org.mapstruct.intellij.util.MapstructAnnotationUtils.findMapperConfigReference;
 import static org.mapstruct.intellij.util.MapstructUtil.INHERIT_CONFIGURATION_FQN;
@@ -470,7 +471,7 @@ public class TargetUtils {
 
         Stream<PsiMethod> candidates = findMappingMethodsFromInheritScope( containingClass, mapperAnnotation );
 
-        Optional<PsiMethod> inheritMappingMethod = findInheritMappingMethod(
+        Optional<PsiMethod> inheritMappingMethod = findSingleMatchingInheritMappingMethod(
             mappingMethod,
             candidates,
             inheritConfigurationAnnotation

--- a/src/main/java/org/mapstruct/intellij/util/TargetUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/TargetUtils.java
@@ -40,15 +40,17 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static com.intellij.codeInsight.AnnotationUtil.findAnnotation;
+import static com.intellij.codeInsight.AnnotationUtil.findDeclaredAttribute;
 import static com.intellij.codeInsight.AnnotationUtil.getBooleanAttributeValue;
 import static org.mapstruct.intellij.util.MapstructAnnotationUtils.findAllDefinedMappingAnnotations;
 import static org.mapstruct.intellij.util.MapstructAnnotationUtils.findMapperConfigReference;
+import static org.mapstruct.intellij.util.MapstructUtil.MAPPER_ANNOTATION_FQN;
 import static org.mapstruct.intellij.util.MapstructUtil.canDescendIntoType;
 import static org.mapstruct.intellij.util.MapstructUtil.isFluentSetter;
 import static org.mapstruct.intellij.util.MapstructUtil.publicFields;
 
 /**
- * Utils for working with target properties (extracting targets  for MapStruct).
+ * Utils for working with target properties (extracting targets for MapStruct).
  *
  * @author Filip Hrisafov
  */
@@ -148,10 +150,10 @@ public class TargetUtils {
     public static boolean isBuilderEnabled(@Nullable PsiMethod mappingMethod) {
         Optional<Boolean> disableBuilder = findDisableBuilder( mappingMethod, MapstructUtil.BEAN_MAPPING_FQN );
 
-        if ( !disableBuilder.isPresent() && mappingMethod != null ) {
+        if ( disableBuilder.isEmpty() && mappingMethod != null ) {
             PsiAnnotation mapperAnnotation = findAnnotation(
                 mappingMethod.getContainingClass(),
-                MapstructUtil.MAPPER_ANNOTATION_FQN
+                MAPPER_ANNOTATION_FQN
             );
             disableBuilder = findDisabledBuilder( mapperAnnotation );
 
@@ -174,7 +176,7 @@ public class TargetUtils {
 
     private static Optional<Boolean> findDisabledBuilder(@Nullable PsiAnnotation requestedAnnotation) {
         if ( requestedAnnotation != null ) {
-            PsiNameValuePair builderAttribute = AnnotationUtil.findDeclaredAttribute( requestedAnnotation, "builder" );
+            PsiNameValuePair builderAttribute = findDeclaredAttribute( requestedAnnotation, "builder" );
             if ( builderAttribute != null ) {
                 PsiAnnotationMemberValue builderValue = builderAttribute.getValue();
                 if ( builderValue instanceof PsiAnnotation ) {
@@ -220,7 +222,7 @@ public class TargetUtils {
             return !constructor.hasModifier( JvmModifier.PRIVATE ) ? constructor : null;
         }
 
-        List<PsiMethod> accessibleConstructors = new ArrayList<>(constructors.length);
+        List<PsiMethod> accessibleConstructors = new ArrayList<>( constructors.length );
 
         for ( PsiMethod constructor : constructors ) {
             if ( constructor.hasModifier( JvmModifier.PRIVATE ) ) {
@@ -415,7 +417,7 @@ public class TargetUtils {
                 psiAnnotation,
                 "target"
             ) ) )
-            .map( psiAnnotation -> AnnotationUtil.findDeclaredAttribute( psiAnnotation, "source" ) )
+            .map( psiAnnotation -> findDeclaredAttribute( psiAnnotation, "source" ) )
             .filter( Objects::nonNull )
             .map( PsiNameValuePair::getValue )
             .filter( Objects::nonNull )

--- a/src/test/java/org/mapstruct/intellij/inspection/InheritConfigurationInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/InheritConfigurationInspectionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.mapstruct.intellij.inspection;
+
+import java.util.List;
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.pom.java.LanguageLevel;
+import org.jetbrains.annotations.NotNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InheritConfigurationInspectionTest extends BaseInspectionTest {
+
+    @NotNull
+    @Override
+    protected Class<UnmappedTargetPropertiesInspection> getInspection() {
+        return UnmappedTargetPropertiesInspection.class;
+    }
+
+    @Override
+    protected LanguageLevel getLanguageLevel() {
+        return super.getLanguageLevel();
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        addDirectoryToProject( "../mapping/dto" );
+    }
+
+    public void testInheritConfigurationByInheritanceMapper() {
+        doTest();
+    }
+
+    public void testInheritConfigurationByMapperConfigMapper() {
+        doTest();
+    }
+
+    public void testInheritConfigurationByNameMapper() {
+
+        configureByTestName();
+
+        myFixture.enableInspections( getInspection() );
+
+        List<HighlightInfo> warnings = myFixture.doHighlighting( HighlightSeverity.WARNING );
+
+        assertThat( warnings )
+            .as( "'carDtoIntoCar' must show no warning, because it should have been inherited" )
+            .hasSize( 1 )
+            .extracting( HighlightInfo::getText )
+            .containsOnly( "carDtoToCarIgnoringSeatCount" );
+    }
+
+    public void testInheritConfigurationBySuperMapperMapper() {
+        doTest();
+    }
+
+    public void testInheritConfigurationInSameClassMapper() {
+        doTest();
+    }
+
+}

--- a/src/test/java/org/mapstruct/intellij/inspection/InheritConfigurationInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/InheritConfigurationInspectionTest.java
@@ -66,4 +66,12 @@ public class InheritConfigurationInspectionTest extends BaseInspectionTest {
         doTest();
     }
 
+    public void testInheritConfigurationInSameClassOfUpdateMethodMapper() {
+        doTest();
+    }
+
+    public void testInheritConfigurationInSameClassWithContextMapper() {
+        doTest();
+    }
+
 }

--- a/testData/inspection/InheritConfigurationByInheritanceMapper.java
+++ b/testData/inspection/InheritConfigurationByInheritanceMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.example.dto.Person;
+import org.example.dto.PersonDto;
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper
+public interface InheritConfigurationByInheritanceMapper {
+
+    @Mapping(target = "fullName", source = "name")
+    PersonDto map(Person person);
+
+    @InheritConfiguration
+    @Mapping(target = "ageInYears", source = "age")
+    NaturalPersonDto map(NaturalPerson naturalPerson);
+
+}
+
+class NaturalPerson extends Person {
+
+    private int age;
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+}
+
+class NaturalPersonDto extends PersonDto {
+
+    private Long ageInYears;
+
+    public Long getAgeInYears() {
+        return ageInYears;
+    }
+
+    public void setAgeInYears(Long ageInYears) {
+        this.ageInYears = ageInYears;
+    }
+
+}

--- a/testData/inspection/InheritConfigurationByMapperConfigMapper.java
+++ b/testData/inspection/InheritConfigurationByMapperConfigMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.example.dto.Car;
+import org.example.dto.CarDto;
+import org.mapstruct.*;
+
+@Mapper(config = InheritMapperConfig.class)
+public interface InheritConfigurationByMapperConfigMapper {
+
+    @InheritConfiguration
+    void carDtoIntoCar(CarDto carDto, @MappingTarget Car car);
+
+}
+
+@MapperConfig
+interface InheritMapperConfig {
+
+    @Mapping(target = "manufacturingDate", source = "manufacturingYear")
+    @Mapping(target = "numberOfSeats", source = "seatCount")
+    @Mapping(target = "free", source = "available")
+    @Mapping(target = "driver", source = "myDriver")
+    Car carDtoToCar(CarDto car);
+
+}

--- a/testData/inspection/InheritConfigurationByNameMapper.java
+++ b/testData/inspection/InheritConfigurationByNameMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.example.dto.Car;
+import org.example.dto.CarDto;
+import org.mapstruct.*;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.WARN)
+public interface InheritConfigurationByNameMapper {
+
+    @Mapping(target = "numberOfSeats", ignore = true)
+    @Mapping(target = "manufacturingDate", source = "manufacturingYear")
+    @Mapping(target = "free", source = "available")
+    // driver missing, must not be highlighted in inherited configuration
+    Car carDtoToCarIgnoringSeatCount(CarDto car);
+
+    @Mapping(target = "manufacturingDate", ignore = true)
+    @Mapping(target = "free", source = "available")
+    @Mapping(target = "driver", source = "myDriver")
+    @Mapping(target = "numberOfSeats", source = "seatCount")
+    Car carDtoToCarIgnoringManufacturingDate(CarDto car);
+
+    @InheritConfiguration(name = "carDtoToCarIgnoringManufacturingDate")
+    void carDtoIntoCar(CarDto carDto, @MappingTarget Car car);
+
+}

--- a/testData/inspection/InheritConfigurationBySuperMapperMapper.java
+++ b/testData/inspection/InheritConfigurationBySuperMapperMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.example.dto.Car;
+import org.example.dto.CarDto;
+import org.mapstruct.*;
+
+@Mapper
+public interface InheritConfigurationBySuperMapperMapper extends SuperMapper, IrrelevantSuperMapper {
+
+    @InheritConfiguration 
+    void carDtoIntoCar(CarDto carDto, @MappingTarget Car car);
+
+}
+
+@Mapper
+interface SuperMapper extends IrrelevantSuperSuperMapper {
+
+    @Mapping(target = "numberOfSeats", ignore = true)
+    @Mapping(target = "manufacturingDate", source = "manufacturingYear")
+    @Mapping(target = "free", source = "available")
+    @Mapping(target = "driver", source = "myDriver")
+    Car carDtoToCarIgnoringSeatCount(CarDto car);
+
+}
+
+
+@Mapper
+interface IrrelevantSuperMapper {
+
+    default String upperCase(String input) {
+        return input.toUpperCase();
+    }
+
+}
+
+@Mapper
+interface IrrelevantSuperSuperMapper {
+
+    default int nullSafeInt(Long input) {
+        if (input != null) {
+            return input.intValue();
+        }
+        return 0;
+    }
+
+}

--- a/testData/inspection/InheritConfigurationInSameClassMapper.java
+++ b/testData/inspection/InheritConfigurationInSameClassMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.example.dto.CarDto;
+import org.example.dto.PersonDto;
+import org.example.dto.Car;
+import org.example.dto.Person;
+
+@Mapper
+public interface InheritConfigurationInSameClassMapper {
+
+    @Mapping(target = "manufacturingDate", source = "manufacturingYear")
+    @Mapping(target = "numberOfSeats", source = "seatCount")
+    @Mapping(target = "free", source = "available")
+    @Mapping(target = "driver", source = "myDriver")
+    Car carDtoToCar(CarDto car);
+
+    @InheritConfiguration  
+    void carDtoIntoCar(CarDto carDto, @MappingTarget Car car);
+
+
+}

--- a/testData/inspection/InheritConfigurationInSameClassOfUpdateMethodMapper.java
+++ b/testData/inspection/InheritConfigurationInSameClassOfUpdateMethodMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.example.dto.CarDto;
+import org.example.dto.PersonDto;
+import org.example.dto.Car;
+import org.example.dto.Person;
+
+@Mapper
+public interface InheritConfigurationInSameClassOfUpdateMethodMapper {
+
+    @InheritConfiguration
+    Car carDtoToCar(CarDto car);
+
+    @Mapping(target = "manufacturingDate", source = "manufacturingYear")
+    @Mapping(target = "numberOfSeats", source = "seatCount")
+    @Mapping(target = "free", source = "available")
+    @Mapping(target = "driver", source = "myDriver")
+    void carDtoIntoCar(CarDto carDto, @MappingTarget Car car);
+
+}

--- a/testData/inspection/InheritConfigurationInSameClassWithContextMapper.java
+++ b/testData/inspection/InheritConfigurationInSameClassWithContextMapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Context;
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.example.dto.CarDto;
+import org.example.dto.PersonDto;
+import org.example.dto.Car;
+import org.example.dto.Person;
+
+@Mapper
+public interface InheritConfigurationInSameClassWithContextMapper {
+
+    @Mapping(target = "manufacturingDate", source = "manufacturingYear")
+    @Mapping(target = "numberOfSeats", source = "seatCount")
+    @Mapping(target = "free", source = "available")
+    @Mapping(target = "driver", source = "myDriver")
+    Car carDtoToCar(CarDto car, @Context Long someContextVariable);
+
+    @InheritConfiguration  
+    void carDtoIntoCar(CarDto carDto, @MappingTarget Car car);
+
+
+}


### PR DESCRIPTION
I could narrow it down to the following use cases:
* `@InheritConfiguration` from a method in...
    * the same mapper (local reference)
    * super mapper
    * by name 
    * a referenced `@MapperConfig`
    * the same mapper (local reference) but with another type that can be inherited from (e.g. inheritance like `Person <- NaturalPerson`)

For all these I have provided a test case.

I am using an approach with two steps:
* search for all possible methods in the scope where `@InheritConfiguration` might be possible
* find a single method that can be inherited from - as you suggested: when there is more than one candidate, nothing will be returned


Fixes #65 