### PR TITLE
#129 improve support of mapping composition 

### DIFF
--- a/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesWithMetaAnnotationInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesWithMetaAnnotationInspectionTest.java
@@ -35,6 +35,16 @@ public class UnmappedTargetPropertiesWithMetaAnnotationInspectionTest extends Ba
             "MetaMappingIgnoreTestName.java",
             "org/example/data/IgnoreTestName.java"
         );
+
+        myFixture.copyFileToProject(
+            "MetaMappingMetaAnnotationChained.java",
+            "org/example/data/AnnotationChained.java"
+        );
+
+        myFixture.copyFileToProject(
+            "MetaMappingMetaAnnotationChainTarget.java",
+            "org/example/data/AnnotationChainTarget.java"
+        );
     }
 
     public void testUnmappedTargetPropertiesWithMetaAnnotation() {
@@ -52,5 +62,13 @@ public class UnmappedTargetPropertiesWithMetaAnnotationInspectionTest extends Ba
 
         allQuickFixes.forEach( myFixture::launchAction );
         myFixture.checkResultByFile( testName + "_after.java" );
+    }
+
+    public void testUnmappedTargetPropertiesWithMetaAnnotationChained() {
+        doTest();
+    }
+
+    public void testUnmappedTargetPropertiesWithMetaAnnotationAndMapping() {
+        doTest();
     }
 }

--- a/testData/inspection/MetaMappingMetaAnnotationChainTarget.java
+++ b/testData/inspection/MetaMappingMetaAnnotationChainTarget.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.example.data;
+
+import org.mapstruct.Mapping;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.CLASS)
+@Mapping(target = "matching", expression = "java(\"matching-value\")")
+@AnnotationChained
+public @interface AnnotationChainTarget {
+}

--- a/testData/inspection/MetaMappingMetaAnnotationChained.java
+++ b/testData/inspection/MetaMappingMetaAnnotationChained.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.example.data;
+
+import org.mapstruct.Mapping;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.CLASS)
+@Mapping(target = "testName", ignore = true)
+@Mapping(target = "moreTarget", constant = "some-value")
+@AnnotationChainTarget
+public @interface AnnotationChained {
+}

--- a/testData/inspection/UnmappedTargetPropertiesWithMetaAnnotationAndMapping.java
+++ b/testData/inspection/UnmappedTargetPropertiesWithMetaAnnotationAndMapping.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.example.data.IgnoreTestName;
+import org.example.data.UnmappedTargetPropertiesData.Target;
+
+@Mapper
+public interface UnmappedTargetPropertiesWithMetaAnnotationAndMapping {
+
+    @IgnoreTestName
+    @Mapping(target = "moreTarget", constant = "some-value")
+    @Mapping(target = "matching", constant = "some-value")
+    Target map(Source source);
+
+    public static class Source {
+        Integer order;
+    }
+
+}

--- a/testData/inspection/UnmappedTargetPropertiesWithMetaAnnotationChained.java
+++ b/testData/inspection/UnmappedTargetPropertiesWithMetaAnnotationChained.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Mapper;
+import org.example.data.AnnotationChained;
+import org.example.data.UnmappedTargetPropertiesData.Target;
+
+@Mapper
+public interface UnmappedTargetPropertiesWithMetaAnnotationChained {
+
+    @AnnotationChained
+    Target map(Source source);
+
+    public static class Source {
+        Integer order;
+    }
+
+}


### PR DESCRIPTION
This PR is about #129.

Mapping composition (or meta annotations) were already tacklet with the following commit (target version 1.2.1): https://github.com/mapstruct/mapstruct-idea/commit/35f171224af8267163f33edcedb92b01d14a3bbc

However, the used utility method `com.intellij.codeInsight.MetaAnnotationUtil#findMetaAnnotations` returns only **a single** (more precise: the first) `@Mapping` annotation. Therefore this did not work as expected (but already worked with the simple test named `UnmappedTargetPropertiesWithMetaAnnotationInspectionTest`.

I implemented an own recursive method to find `@Mapping` annotations and provided a test case with an infinitve chained meta-annotation.
I also added a test with combined `@Mapping` and meta-annotation on the same mapping method. The current implementation did not merge them together but worked against each other.

---

Sidenote: The intellij utility method `MetaAnnotationUtil#findMetaAnnotations` used an internal cache. I chose against using one, because it felt like a premature optimization which made the code less readable. Let me know what you think, especially because of the TODO comments to use a cache in line 300 😆

If we/you really want this, we should do this in a separate issue/PR with a clean cache solution outsourced in a separate class to keep the code clean.

I can also improve this with the current PR. Let me know what you think.