### PR TITLE
upgrade commons-text

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter-engine')
     testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
     testImplementation('org.assertj:assertj-core:3.11.1')
-    testImplementation('org.apache.commons:commons-text:1.9')
+    testImplementation('org.apache.commons:commons-text:1.10.0')
 }
 
 task libs(type: Sync) {


### PR DESCRIPTION
I upgrade `commons-text` to 1.10.0 to prevent any use of [CVE-2022-4288](https://devhub.checkmarx.com/cve-details/CVE-2022-42889/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea&utm_term=maven). 
Currently this dependency is only used in tests, so the main plugin is not effected, but still it should be upgraded. 
The effected `StringSubstitutor`  is used in tests.