### PR TITLE
fix IndexOutOfBoundsException for target methods without parameter

### DIFF
--- a/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructTargetReference.java
+++ b/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructTargetReference.java
@@ -199,6 +199,10 @@ class MapstructTargetReference extends MapstructBaseReference {
      * @return the type of the first parameter of the method
      */
     private static PsiType firstParameterPsiType(PsiMethod psiMethod) {
-        return psiMethod.getParameterList().getParameters()[0].getType();
+        PsiParameter[] psiParameters = psiMethod.getParameterList().getParameters();
+        if ( psiParameters.length == 0) {
+            return null;
+        }
+        return psiParameters[0].getType();
     }
 }

--- a/src/main/java/org/mapstruct/intellij/expression/JavaExpressionInjector.java
+++ b/src/main/java/org/mapstruct/intellij/expression/JavaExpressionInjector.java
@@ -177,7 +177,11 @@ public class JavaExpressionInjector implements MultiHostInjector {
                         if ( references.length > 0 ) {
                             PsiElement resolved = references[0].resolve();
                             if ( resolved instanceof PsiMethod ) {
-                                targetType = ( (PsiMethod) resolved ).getParameterList().getParameters()[0].getType();
+                                PsiParameter[] psiParameters =
+                                        ((PsiMethod) resolved).getParameterList().getParameters();
+                                if ( psiParameters.length > 0) {
+                                    targetType = psiParameters[0].getType();
+                                }
                             }
                             else if ( resolved instanceof PsiParameter ) {
                                 targetType = ( (PsiParameter) resolved ).getType();

--- a/src/test/java/org/mapstruct/intellij/bugs/_110/MethodeWithNoParametersTest.java
+++ b/src/test/java/org/mapstruct/intellij/bugs/_110/MethodeWithNoParametersTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.intellij.bugs._110;
+
+import org.mapstruct.intellij.MapstructBaseCompletionTestCase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author hdulme
+ */
+public class MethodeWithNoParametersTest extends MapstructBaseCompletionTestCase {
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/bugs/_110";
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        myFixture.copyFileToProject( "TargetNoPropertyMethode.java",
+                "org/example/TargetNoPropertyMethode.java" );
+    }
+
+    public void testExpressionCompletion() {
+        myFixture.configureByFile( "MapExpression.java" );
+        assertThat( myFixture.completeBasic() ).isEmpty();
+    }
+
+    public void testDefaultExpressionCompletion() {
+        myFixture.configureByFile( "MapDefaultExpression.java" );
+        assertThat( myFixture.completeBasic() ).isEmpty();
+    }
+
+    public void testTargetCompletion() {
+        myFixture.configureByFile( "TargetCompletion.java" );
+        assertThat( myFixture.completeBasic() ).isEmpty();
+    }
+}

--- a/src/test/java/org/mapstruct/intellij/bugs/_110/MethodeWithNoParametersTest.java
+++ b/src/test/java/org/mapstruct/intellij/bugs/_110/MethodeWithNoParametersTest.java
@@ -22,7 +22,7 @@ public class MethodeWithNoParametersTest extends MapstructBaseCompletionTestCase
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        myFixture.copyFileToProject( "TargetNoPropertyMethode.java",
+        myFixture.copyFileToProject( "TargetNoPropertyMethods.java",
                 "org/example/TargetNoPropertyMethode.java" );
     }
 

--- a/testData/bugs/_110/MapDefaultExpression.java
+++ b/testData/bugs/_110/MapDefaultExpression.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+import org.mapstruct.*;
+import org.example.TargetNoPropertyMethode;
+
+@Mapper
+public interface MapExpression {
+
+    @Mapping(target = "active", defaultExpression = "java(<caret>)")
+    TargetNoPropertyMethode mapDefaultExpression(String string)
+}

--- a/testData/bugs/_110/MapExpression.java
+++ b/testData/bugs/_110/MapExpression.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+import org.mapstruct.*;
+import org.example.TargetNoPropertyMethode;
+
+@Mapper
+public interface MapExpression {
+
+    @Mapping(target = "active", expression = "java(<caret>)")
+    TargetNoPropertyMethode mapExpression(String string)
+}

--- a/testData/bugs/_110/TargetCompletion.java
+++ b/testData/bugs/_110/TargetCompletion.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+import org.mapstruct.*;
+import org.example.TargetNoPropertyMethode;
+
+@Mapper
+public interface MapExpression {
+
+    @Mapping(target = "active.<caret>")
+    TargetNoPropertyMethode mapExpression(String string)
+}

--- a/testData/bugs/_110/TargetNoPropertyMethode.java
+++ b/testData/bugs/_110/TargetNoPropertyMethode.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.example;
+
+public class TargetNoPropertyMethode {
+
+    public void setActive() {
+
+    }
+}

--- a/testData/bugs/_110/TargetNoPropertyMethods.java
+++ b/testData/bugs/_110/TargetNoPropertyMethods.java
@@ -5,7 +5,7 @@
  */
 package org.example;
 
-public class TargetNoPropertyMethode {
+public class TargetNoPropertyMethods {
 
     public void setActive() {
 


### PR DESCRIPTION
I was able to reproduce #110. The error occurs when the target method has no parameters and the IDE tries to evaluate the expression. I found that the same problem results in a crash if you try to complete an sub-method of such an target.
I provided testcases for both problems and the fixes.

Fixes #110 