### PR TITLE
Fix auto-completion for nested public fields

### DIFF
--- a/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructSourceReference.java
+++ b/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructSourceReference.java
@@ -124,6 +124,7 @@ class MapstructSourceReference extends MapstructBaseReference {
     @Override
     PsiType resolvedType() {
         PsiElement element = resolve();
+
         if ( element instanceof PsiMethod ) {
             return ( (PsiMethod) element ).getReturnType();
         }
@@ -132,6 +133,9 @@ class MapstructSourceReference extends MapstructBaseReference {
         }
         else if ( element instanceof PsiRecordComponent ) {
             return ( (PsiRecordComponent) element ).getType();
+        }
+        else if ( element instanceof PsiField ) {
+            return ( (PsiField) element ).getType();
         }
 
         return null;

--- a/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructTargetReference.java
+++ b/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructTargetReference.java
@@ -166,6 +166,10 @@ class MapstructTargetReference extends MapstructBaseReference {
         else if ( element instanceof PsiRecordComponent ) {
             return ( (PsiRecordComponent) element ).getType();
         }
+        else if ( element instanceof PsiField ) {
+            return ( (PsiField) element ).getType();
+        }
+
         return null;
     }
 

--- a/src/test/java/org/mapstruct/intellij/MapstructCompletionTestCase.java
+++ b/src/test/java/org/mapstruct/intellij/MapstructCompletionTestCase.java
@@ -258,6 +258,21 @@ public class MapstructCompletionTestCase extends MapstructBaseCompletionTestCase
             );
     }
 
+    private void assertNestedSecondLevelAutoCompleteProperty() {
+        assertThat( myItems )
+            .extracting( LookupElement::getLookupString )
+            .containsExactlyInAnyOrder(
+                "name"
+            );
+
+        assertThat( myItems )
+            .extracting( LookupElementPresentation::renderElement )
+            .usingRecursiveFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                createVariable( "name", "String" )
+            );
+    }
+
     public void testCarMapperReturnTargetCarDtoKotlin() {
         configureByFile( "/" + getTestName( false ) + ".kt" );
         assertCarDtoAutoCompleteKt();
@@ -378,34 +393,17 @@ public class MapstructCompletionTestCase extends MapstructBaseCompletionTestCase
 
     public void testNestedSecondLevelAutoCompleteTargetProperty() {
         configureByTestName();
-        assertThat( myItems )
-            .extracting( LookupElement::getLookupString )
-            .containsExactlyInAnyOrder(
-                "name"
-            );
+        assertNestedSecondLevelAutoCompleteProperty();
+    }
 
-        assertThat( myItems )
-            .extracting( LookupElementPresentation::renderElement )
-            .usingRecursiveFieldByFieldElementComparator()
-            .containsExactlyInAnyOrder(
-                createVariable( "name", "String" )
-            );
+    public void testNestedSecondLevelAutoCompleteTargetPublicProperty() {
+        configureByTestName();
+        assertNestedSecondLevelAutoCompleteProperty();
     }
 
     public void testNestedSecondLevelAutoCompleteBuilderTargetProperty() {
         configureByTestName();
-        assertThat( myItems )
-            .extracting( LookupElement::getLookupString )
-            .containsExactlyInAnyOrder(
-                "name"
-            );
-
-        assertThat( myItems )
-            .extracting( LookupElementPresentation::renderElement )
-            .usingRecursiveFieldByFieldElementComparator()
-            .containsExactlyInAnyOrder(
-                createVariable( "name", "String" )
-            );
+        assertNestedSecondLevelAutoCompleteProperty();
     }
 
     public void testNestedSecondLevelAutoCompleteConstructorTargetProperty() {
@@ -479,18 +477,12 @@ public class MapstructCompletionTestCase extends MapstructBaseCompletionTestCase
 
     public void testNestedSecondLevelAutoCompleteSourceProperty() {
         configureByTestName();
-        assertThat( myItems )
-            .extracting( LookupElement::getLookupString )
-            .containsExactlyInAnyOrder(
-                "name"
-            );
+        assertNestedSecondLevelAutoCompleteProperty();
+    }
 
-        assertThat( myItems )
-            .extracting( LookupElementPresentation::renderElement )
-            .usingRecursiveFieldByFieldElementComparator()
-            .containsExactlyInAnyOrder(
-                createVariable( "name", "String" )
-            );
+    public void testNestedSecondLevelAutoCompleteSourcePublicProperty() {
+        configureByTestName();
+        assertNestedSecondLevelAutoCompleteProperty();
     }
 
     public void testFluentGenericTargetMapper() {

--- a/testData/mapping/NestedSecondLevelAutoCompleteSourcePublicProperty.java
+++ b/testData/mapping/NestedSecondLevelAutoCompleteSourcePublicProperty.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.example.dto.CarPublic;
+import org.example.dto.CarDtoPublic;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper
+public interface CarMapper {
+
+    @Mapping(source = "driver.<caret>name", target = "myDriver.name")
+    CarDtoPublic carToCarDto(CarPublic car);
+}

--- a/testData/mapping/NestedSecondLevelAutoCompleteTargetPublicProperty.java
+++ b/testData/mapping/NestedSecondLevelAutoCompleteTargetPublicProperty.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.example.dto.CarPublic;
+import org.example.dto.CarDtoPublic;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper
+public interface CarMapper {
+
+    @Mapping(source = "driver.name", target = "myDriver.<caret>name")
+    CarDtoPublic carToCarDto(CarPublic car);
+}


### PR DESCRIPTION
I wanted to reproduce another bug and stumbled accross the lack of support for auto-completion of nested properties when they are public fields.

I provided a test case and fixed it although this is possibly an edge case.