### PR TITLE
add support for collection targets from getter

### DIFF
--- a/src/test/java/org/mapstruct/intellij/inspection/UnmappedCollectionGetterPropertiesInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/UnmappedCollectionGetterPropertiesInspectionTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.intellij.inspection;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class UnmappedCollectionGetterPropertiesInspectionTest extends BaseInspectionTest {
+
+    @NotNull
+    @Override
+    protected Class<UnmappedTargetPropertiesInspection> getInspection() {
+        return UnmappedTargetPropertiesInspection.class;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        myFixture.copyFileToProject(
+            "UnmappedCollectionGetterPropertiesData.java",
+            "org/example/data/UnmappedCollectionGetterPropertiesData.java"
+        );
+    }
+
+    public void testUnmappedCollectionGetterProperties() {
+        doTest();
+        List<IntentionAction> allQuickFixes = myFixture.getAllQuickFixes();
+
+        assertThat( allQuickFixes )
+            .extracting( IntentionAction::getText )
+            .as( "Intent Text" )
+                .containsExactlyInAnyOrder(
+                        "Ignore unmapped target property: 'listTarget'",
+                        "Add unmapped target property: 'listTarget'",
+                        "Ignore unmapped target property: 'setTarget'",
+                        "Add unmapped target property: 'setTarget'",
+                        "Ignore unmapped target property: 'mapTarget'",
+                        "Add unmapped target property: 'mapTarget'",
+                        "Ignore all unmapped target properties"
+            );
+
+        allQuickFixes.forEach( myFixture::launchAction );
+    }
+}

--- a/testData/inspection/UnmappedCollectionGetterProperties.java
+++ b/testData/inspection/UnmappedCollectionGetterProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Mappings;
+import org.example.data.UnmappedCollectionGetterPropertiesData.Target;
+import org.example.data.UnmappedCollectionGetterPropertiesData.Source;
+
+interface NotMapStructMapper {
+
+    Target map(Source source);
+}
+
+@Mapper
+interface NoMappingMapper {
+
+    Target <warning descr="Unmapped target properties: listTarget, mapTarget, setTarget">map</warning>(Source source);
+
+    @org.mapstruct.InheritInverseConfiguration
+    Source reverse(Target target);
+}
+
+@Mapper
+interface AllMappingMapper {
+
+    @Mapping(target = "listTarget", source = "listSource")
+    @Mapping(target = "setTarget", source = "setSource")
+    @Mapping(target = "mapTarget", source = "mapSource")
+    Target mapWithAllMapping(Source source);
+}

--- a/testData/inspection/UnmappedCollectionGetterPropertiesData.java
+++ b/testData/inspection/UnmappedCollectionGetterPropertiesData.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.example.data;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class UnmappedCollectionGetterPropertiesData {
+    public static class Source {
+
+        private List<String> listSource;
+        private Set<Strinf> setSource;
+        private Map<String, String> mapSource;
+
+        public List<String> getListSource() {
+            return listSource;
+        }
+
+        public Set<Strinf> getSetSource() {
+            return setSource;
+        }
+
+        public Map<String, String> getMapSource() {
+            return mapSource;
+        }
+    }
+
+    public static class Target {
+
+        private List<String> listTarget;
+        private Set<Strinf> setTarget;
+        private Map<String, String> mapTarget;
+        private String stringTarget;
+
+        public List<String> getListTarget() {
+            return listTarget;
+        }
+
+        public Set<Strinf> getSetTarget() {
+            return setTarget;
+        }
+
+        public Map<String, String> getMapTarget() {
+            return mapTarget;
+        }
+
+        public String getStringTarget() {
+            return stringTarget;
+        }
+    }
+
+}


### PR DESCRIPTION
Currently, mapstruct supports getter targets where the return-type is instance of a collection.