### PR TITLE
Add IntelliJ 2023.2 and remove 2021.2, 2021.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,11 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - { jdk: 11, idea: 2021.2 }
-          - { jdk: 11, idea: 2021.3 }
           - { jdk: 11, idea: 2022.1 }
           - { jdk: 17, idea: 2022.2 }
           - { jdk: 17, idea: 2022.3 }
           - { jdk: 17, idea: 2023.1 }
+          - { jdk: 17, idea: 2023.2 }
           - { jdk: 17, idea: LATEST-EAP-SNAPSHOT }
     name: 'IDEA ${{ matrix.version.idea }}'
     env:

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ task libs(type: Sync) {
     rename 'mapstruct-1.5.3.Final.jar', 'mapstruct.jar'
 }
 
-def mockJdkLocation = "https://github.com/JetBrains/intellij-community/raw/master/java/mock"
+def mockJdkLocation = "https://github.com/JetBrains/intellij-community/raw/212.5712/java/mock"
 def mockJdkDest = "$buildDir/mock"
 def downloadMockJdk(mockJdkLocation, mockJdkDest, mockJdkVersion) {
     def location = mockJdkLocation + mockJdkVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-ideaVersion = 2021.2
+ideaVersion = 2022.1
 ideaType = IC
 sources = true
 isEAP = false


### PR DESCRIPTION
Adding `2023.2` (since EAP is already `2023.3.xxx`)

Also removed the pipelines for the oldest versions `2021.2` and `2021.3`.
The git history showed that there have never been more than 7 different IntelliJ versions.

@filiphr WDYT, should we still keep them?