### PR TITLE
#159 support fluent setters with super types (e.g. lomboks @SuperBuilder)

### DIFF
--- a/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
@@ -211,18 +211,18 @@ public final class MapstructUtil {
             isAssignableFromReturnTypeOrSuperTypes( psiType, method.getReturnType() );
     }
 
-    private static boolean isAssignableFromReturnTypeOrSuperTypes(PsiType psiType, @Nullable PsiType returnType) {
-
-        if ( returnType == null ) {
-            return false;
-        }
+    private static boolean isAssignableFromReturnTypeOrSuperTypes(PsiType psiType, PsiType returnType) {
 
         if ( isAssignableFrom( psiType, returnType ) ) {
             return true;
         }
 
-        return Arrays.stream( returnType.getSuperTypes() )
-            .anyMatch( superType -> isAssignableFrom( psiType, superType ) );
+        for ( PsiType superType : returnType.getSuperTypes() ) {
+            if ( isAssignableFrom( psiType, superType ) ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static boolean isAssignableFrom(PsiType psiType, @Nullable PsiType returnType) {

--- a/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
@@ -6,7 +6,6 @@
 package org.mapstruct.intellij.util;
 
 import java.beans.Introspector;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/src/test/java/org/mapstruct/intellij/inspection/UnmappedSuperBuilderTargetPropertiesInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/UnmappedSuperBuilderTargetPropertiesInspectionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.intellij.inspection;
+
+import java.util.List;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import org.jetbrains.annotations.NotNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Oliver Erhart
+ */
+public class UnmappedSuperBuilderTargetPropertiesInspectionTest extends BaseInspectionTest {
+
+    @NotNull
+    @Override
+    protected Class<UnmappedTargetPropertiesInspection> getInspection() {
+        return UnmappedTargetPropertiesInspection.class;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        myFixture.copyFileToProject(
+            "UnmappedSuperBuilderTargetPropertiesData.java",
+            "org/example/data/UnmappedSuperBuilderTargetPropertiesData.java"
+        );
+    }
+
+    public void testUnmappedSuperBuilderTargetProperties() {
+        doTest();
+        String testName = getTestName( false );
+        List<IntentionAction> allQuickFixes = myFixture.getAllQuickFixes();
+
+        assertThat( allQuickFixes )
+            .extracting( IntentionAction::getText )
+            .as( "Intent Text" )
+            .containsExactly(
+                "Ignore unmapped target property: 'testName'",
+                "Add unmapped target property: 'testName'",
+                "Ignore unmapped target property: 'moreTarget'",
+                "Add unmapped target property: 'moreTarget'",
+                "Ignore unmapped target property: 'moreTarget'",
+                "Add unmapped target property: 'moreTarget'",
+                "Ignore unmapped target property: 'testName'",
+                "Add unmapped target property: 'testName'",
+                "Ignore all unmapped target properties",
+                "Ignore unmapped target property: 'testName'",
+                "Add unmapped target property: 'testName'",
+                "Ignore unmapped target property: 'moreTarget'",
+                "Add unmapped target property: 'moreTarget'"
+            );
+
+        allQuickFixes.forEach( myFixture::launchAction );
+        myFixture.checkResultByFile( testName + "_after.java" );
+    }
+}

--- a/testData/inspection/UnmappedSuperBuilderTargetProperties.java
+++ b/testData/inspection/UnmappedSuperBuilderTargetProperties.java
@@ -5,12 +5,13 @@
  */
 
 import org.mapstruct.Context;
+import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Mappings;
-import org.example.data.UnmappedFluentTargetPropertiesData.Target;
-import org.example.data.UnmappedFluentTargetPropertiesData.Source;
+import org.example.data.UnmappedSuperBuilderTargetPropertiesData.Target;
+import org.example.data.UnmappedSuperBuilderTargetPropertiesData.Source;
 
 interface NotMapStructMapper {
 
@@ -38,7 +39,7 @@ interface NoMappingMapper {
 
     Target <warning descr="Unmapped target properties: moreTarget, testName">map</warning>(Source source);
 
-    @org.mapstruct.InheritInverseConfiguration
+    @InheritInverseConfiguration
     Source reverse(Target target);
 }
 

--- a/testData/inspection/UnmappedSuperBuilderTargetProperties.java
+++ b/testData/inspection/UnmappedSuperBuilderTargetProperties.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Mappings;
+import org.example.data.UnmappedFluentTargetPropertiesData.Target;
+import org.example.data.UnmappedFluentTargetPropertiesData.Source;
+
+interface NotMapStructMapper {
+
+    Target map(Source source);
+}
+
+@Mapper
+interface SingleMappingsMapper {
+
+    @Mappings({
+        @Mapping(target = "moreTarget", source = "moreSource")
+    })
+    Target <warning descr="Unmapped target property: testName">map</warning>(Source source);
+}
+
+@Mapper
+interface SingleMappingMapper {
+
+    @Mapping(target = "testName", source = "name")
+    Target <warning descr="Unmapped target property: moreTarget">map</warning>(Source source);
+}
+
+@Mapper
+interface NoMappingMapper {
+
+    Target <warning descr="Unmapped target properties: moreTarget, testName">map</warning>(Source source);
+
+    @org.mapstruct.InheritInverseConfiguration
+    Source reverse(Target target);
+}
+
+@Mapper
+interface AllMappingMapper {
+
+    @Mapping(target = "testName", source = "name")
+    @Mapping(target = "moreTarget", source = "moreSource")
+    Target mapWithAllMapping(Source source);
+}
+
+@Mapper
+interface UpdateMapper {
+
+    @Mapping(target = "moreTarget", source = "moreSource")
+    void <warning descr="Unmapped target property: testName">update</warning>(@MappingTarget Target target, Source source);
+}
+
+@Mapper
+interface MultiSourceUpdateMapper {
+
+    void <warning descr="Unmapped target property: moreTarget">update</warning>(@MappingTarget Target moreTarget, Source source, String testName, @Context String matching);
+}

--- a/testData/inspection/UnmappedSuperBuilderTargetPropertiesData.java
+++ b/testData/inspection/UnmappedSuperBuilderTargetPropertiesData.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.example.data;
+
+public class UnmappedFluentTargetPropertiesData {
+    public static class Source {
+
+        private String name;
+        private String matching;
+        private String moreSource;
+        private String onlyInSource;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getMatching() {
+            return matching;
+        }
+
+        public void setMatching(String matching) {
+            this.matching = matching;
+        }
+
+        public String getMoreSource() {
+            return moreSource;
+        }
+
+        public void setMoreSource(String moreSource) {
+            this.moreSource = moreSource;
+        }
+
+        public String getOnlyInSource() {
+            return onlyInSource;
+        }
+
+        public void setOnlyInSource(String onlyInSource) {
+            this.onlyInSource = onlyInSource;
+        }
+    }
+
+    public static class Target {
+
+        private String testName;
+        private String matching;
+        private String moreTarget;
+
+        protected Target(TargetBuilder<?, ?> b) {
+            this.testName = b.testName;
+            this.matching = b.matching;
+            this.moreTarget = b.moreTarget;
+        }
+
+        public static TargetBuilder<?, ?> builder() {
+            return new TargetBuilderImpl();
+        }
+
+        public String getTestName() {
+            return this.testName;
+        }
+
+        public String getMatching() {
+            return this.matching;
+        }
+
+        public String getMoreTarget() {
+            return this.moreTarget;
+        }
+
+        public void setTestName(String testName) {
+            this.testName = testName;
+        }
+
+        public void setMatching(String matching) {
+            this.matching = matching;
+        }
+
+        public void setMoreTarget(String moreTarget) {
+            this.moreTarget = moreTarget;
+        }
+
+        public static abstract class TargetBuilder<C extends Target, B extends TargetBuilder<C, B>> {
+            private String testName;
+            private String matching;
+            private String moreTarget;
+
+            public B testName(String testName) {
+                this.testName = testName;
+                return self();
+            }
+
+            public B matching(String matching) {
+                this.matching = matching;
+                return self();
+            }
+
+            public B moreTarget(String moreTarget) {
+                this.moreTarget = moreTarget;
+                return self();
+            }
+
+            protected abstract B self();
+
+            public abstract C build();
+
+            public String toString() {
+                return "Target.TargetBuilder(testName=" + this.testName + ", matching=" + this.matching + ", moreTarget=" +
+                    this.moreTarget + ")";
+            }
+        }
+
+        private static final class TargetBuilderImpl extends TargetBuilder<Target, TargetBuilderImpl> {
+            private TargetBuilderImpl() {
+            }
+
+            protected TargetBuilderImpl self() {
+                return this;
+            }
+
+            public Target build() {
+                return new Target( this );
+            }
+        }
+    }
+
+}

--- a/testData/inspection/UnmappedSuperBuilderTargetPropertiesData.java
+++ b/testData/inspection/UnmappedSuperBuilderTargetPropertiesData.java
@@ -5,7 +5,7 @@
  */
 package org.example.data;
 
-public class UnmappedFluentTargetPropertiesData {
+public class UnmappedSuperBuilderTargetPropertiesData {
     public static class Source {
 
         private String name;
@@ -109,11 +109,6 @@ public class UnmappedFluentTargetPropertiesData {
             protected abstract B self();
 
             public abstract C build();
-
-            public String toString() {
-                return "Target.TargetBuilder(testName=" + this.testName + ", matching=" + this.matching + ", moreTarget=" +
-                    this.moreTarget + ")";
-            }
         }
 
         private static final class TargetBuilderImpl extends TargetBuilder<Target, TargetBuilderImpl> {

--- a/testData/inspection/UnmappedSuperBuilderTargetProperties_after.java
+++ b/testData/inspection/UnmappedSuperBuilderTargetProperties_after.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Mappings;
+import org.example.data.UnmappedFluentTargetPropertiesData.Target;
+import org.example.data.UnmappedFluentTargetPropertiesData.Source;
+
+interface NotMapStructMapper {
+
+    Target map(Source source);
+}
+
+@Mapper
+interface SingleMappingsMapper {
+
+    @Mappings({
+            @Mapping(target = "moreTarget", source = "moreSource"),
+            @Mapping(target = "testName", ignore = true),
+            @Mapping(target = "testName", source = "")
+    })
+    Target map(Source source);
+}
+
+@Mapper
+interface SingleMappingMapper {
+
+    @Mapping(target = "moreTarget", source = "")
+    @Mapping(target = "moreTarget", ignore = true)
+    @Mapping(target = "testName", source = "name")
+    Target map(Source source);
+}
+
+@Mapper
+interface NoMappingMapper {
+
+    @Mapping(target = "testName", ignore = true)
+    @Mapping(target = "moreTarget", ignore = true)
+    @Mapping(target = "testName", source = "")
+    @Mapping(target = "testName", ignore = true)
+    @Mapping(target = "moreTarget", source = "")
+    @Mapping(target = "moreTarget", ignore = true)
+    Target map(Source source);
+
+    @org.mapstruct.InheritInverseConfiguration
+    Source reverse(Target target);
+}
+
+@Mapper
+interface AllMappingMapper {
+
+    @Mapping(target = "testName", source = "name")
+    @Mapping(target = "moreTarget", source = "moreSource")
+    Target mapWithAllMapping(Source source);
+}
+
+@Mapper
+interface UpdateMapper {
+
+    @Mapping(target = "testName", source = "")
+    @Mapping(target = "testName", ignore = true)
+    @Mapping(target = "moreTarget", source = "moreSource")
+    void update(@MappingTarget Target target, Source source);
+}
+
+@Mapper
+interface MultiSourceUpdateMapper {
+
+    @Mapping(target = "moreTarget", source = "")
+    @Mapping(target = "moreTarget", ignore = true)
+    void update(@MappingTarget Target moreTarget, Source source, String testName, @Context String matching);
+}

--- a/testData/inspection/UnmappedSuperBuilderTargetProperties_after.java
+++ b/testData/inspection/UnmappedSuperBuilderTargetProperties_after.java
@@ -5,12 +5,13 @@
  */
 
 import org.mapstruct.Context;
+import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Mappings;
-import org.example.data.UnmappedFluentTargetPropertiesData.Target;
-import org.example.data.UnmappedFluentTargetPropertiesData.Source;
+import org.example.data.UnmappedSuperBuilderTargetPropertiesData.Target;
+import org.example.data.UnmappedSuperBuilderTargetPropertiesData.Source;
 
 interface NotMapStructMapper {
 
@@ -48,7 +49,7 @@ interface NoMappingMapper {
     @Mapping(target = "moreTarget", ignore = true)
     Target map(Source source);
 
-    @org.mapstruct.InheritInverseConfiguration
+    @InheritInverseConfiguration
     Source reverse(Target target);
 }
 


### PR DESCRIPTION
I hope this change has no unwanted side effects. It checks whether a fluent setters return type also can be assigned to one of its super types to support classes like this:
```java
public static abstract class TargetBuilder<C extends Target, B extends TargetBuilder<C, B>> {

            private String testName;

            public B testName(String testName) {
                this.testName = testName;
                return self();
            }
            // ...
}
```

Fixes #159