### PR TITLE
update since-build to 213

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -24,7 +24,7 @@
   <vendor url="https://www.mapstruct.org">MapStruct</vendor>
 
   <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-  <idea-version since-build="212"/>
+  <idea-version since-build="213"/>
 
   <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
        on how to target different products -->


### PR DESCRIPTION
Currently the plugin uses `com.intellij.codeInspection.DefaultAnnotationParamInspection.IgnoreAnnotationParamSupport` and overrides `com.intellij.openapi.options.UnnamedConfigurable`. Both are available since 212.4746.92. To prevent issue with older 212.* versions, I upgrade the required version to 213 (2021.3).