### PR TITLE
match Java expression core implementation

### DIFF
--- a/src/main/java/org/mapstruct/intellij/expression/JavaExpressionInjector.java
+++ b/src/main/java/org/mapstruct/intellij/expression/JavaExpressionInjector.java
@@ -49,7 +49,7 @@ import org.mapstruct.intellij.util.MapstructUtil;
  */
 public class JavaExpressionInjector implements MultiHostInjector {
 
-    public static final Pattern JAVA_EXPRESSION = Pattern.compile( "\" *java\\(.*\\) *\"" );
+    public static final Pattern JAVA_EXPRESSION = Pattern.compile( "^\"\\s*java\\((.*)\\)\\s*\"$", Pattern.DOTALL );
 
     private static final ElementPattern<PsiElement> PATTERN =
         StandardPatterns.or(


### PR DESCRIPTION
@filiphr I changed the implementation to match the [core](https://github.com/mapstruct/mapstruct/blob/fa857e9ff46b5bb3e5a6c2c8b1c56009944f5ef3/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java#L40)  implementation as you suggested in #164. The only difference is that idea needs the `\"` at the beginning and end of the string.