### PR TITLE
update Gradle IntelliJ Plugin to 1.16.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import com.hierynomus.gradle.license.tasks.LicenseCheck
 import com.hierynomus.gradle.license.tasks.LicenseFormat
 
 plugins {
-    id "org.jetbrains.intellij" version "1.13.3"
+    id "org.jetbrains.intellij" version "1.16.1"
     id "com.github.hierynomus.license" version "0.16.1"
     id "de.undercouch.download" version "5.4.0"
 }


### PR DESCRIPTION
I upgrade the  Gradle IntelliJ Plugin to the latest version. It is recommended to use the latest version. The complete changelog can be found here [https://github.com/JetBrains/gradle-intellij-plugin/releases](https://github.com/JetBrains/gradle-intellij-plugin/releases)