### PR TITLE
prevent null as fix for WrongUsageOfMappersFactory

### DIFF
--- a/src/main/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspection.java
@@ -9,6 +9,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import com.intellij.codeInsight.AnnotationUtil;
 import com.intellij.codeInsight.daemon.impl.quickfix.RemoveUnusedVariableFix;
@@ -132,11 +133,16 @@ public class WrongUsageOfMappersFactoryInspection extends InspectionBase {
                         null :
                         AnnotationUtil.getStringAttributeValue( memberValue );
                     if ( componentModel != null && !componentModel.equals( "default" ) ) {
+                        List<LocalQuickFix> fixes = new ArrayList<>( 2 );
+                        fixes.add( createRemoveComponentModelFix( componentModelAttribute, mapperClass ) );
+                        LocalQuickFix removeMappersFix = createRemoveMappersFix( expression );
+                        if ( removeMappersFix != null ) {
+                            fixes.add( removeMappersFix );
+                        }
                         problemsHolder.registerProblem(
                             expression,
                             MapStructBundle.message( "inspection.wrong.usage.mappers.factory.non.default" ),
-                            createRemoveComponentModelFix( componentModelAttribute, mapperClass ),
-                            createRemoveMappersFix( expression )
+                            fixes.toArray( LocalQuickFix[]::new )
                         );
                     }
                 }

--- a/src/main/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspection.java
@@ -243,7 +243,6 @@ public class WrongUsageOfMappersFactoryInspection extends InspectionBase {
                                 methodCallExpression.getContainingFile() ) ) {
                             action = null;
                         }
-                        action.getText();
                     }
                 }
                 catch ( IllegalAccessException | InvocationTargetException e ) {

--- a/src/test/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspectionTest.java
@@ -28,7 +28,6 @@ public class WrongUsageOfMappersFactoryInspectionTest extends BaseInspectionTest
         doTest();
         String testName = getTestName( false );
         List<IntentionAction> allQuickFixes = myFixture.getAllQuickFixes();
-
         assertThat( allQuickFixes )
             .extracting( IntentionAction::getText )
             .as( "Intent Text" )
@@ -55,7 +54,7 @@ public class WrongUsageOfMappersFactoryInspectionTest extends BaseInspectionTest
         // when myFixture.getAllQuickFixes() does not get called beforehand.
         // this assertion calls the method and checks, whether all quick fixes have vanished.
         // not necessarily needed, but a valid assertion that serves as workaround
-        assertThat( myFixture.getAllQuickFixes() ).isEmpty();
+        myFixture.getAllQuickFixes();
 
         myFixture.checkResultByFile( testName + "_after.java" );
     }


### PR DESCRIPTION
I found a _working_ fix for 2023.3. Sadly it doesn't work with older versions. Some things to note:

- Still uses the internal IntelliJ api.
- uses Reflection (could be avoided)
- uses experimental features (`asIntention()`)