### PR TITLE
Fix issue 180. WrongUsageOfMappersFactory componentModel from config

### DIFF
--- a/src/main/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspection.java
@@ -46,7 +46,7 @@ public class WrongUsageOfMappersFactoryInspection extends InspectionBase {
         MapstructUtil.MAPPERS_FQN,
         "getMapper"
     ).parameterTypes( CommonClassNames.JAVA_LANG_CLASS );
-    public static final String COMPONENT_MODEL = "componentModel";
+    private static final String COMPONENT_MODEL = "componentModel";
 
     @NotNull
     @Override

--- a/src/main/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspection.java
@@ -29,6 +29,7 @@ import com.siyeh.ig.callMatcher.CallMatcher;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.mapstruct.intellij.MapStructBundle;
+import org.mapstruct.intellij.util.MapstructAnnotationUtils;
 import org.mapstruct.intellij.util.MapstructUtil;
 
 import java.util.ArrayList;
@@ -45,6 +46,7 @@ public class WrongUsageOfMappersFactoryInspection extends InspectionBase {
         MapstructUtil.MAPPERS_FQN,
         "getMapper"
     ).parameterTypes( CommonClassNames.JAVA_LANG_CLASS );
+    public static final String COMPONENT_MODEL = "componentModel";
 
     @NotNull
     @Override
@@ -103,17 +105,24 @@ public class WrongUsageOfMappersFactoryInspection extends InspectionBase {
                 else {
                     PsiNameValuePair componentModelAttribute = AnnotationUtil.findDeclaredAttribute(
                         mapperAnnotation,
-                        "componentModel"
+                            COMPONENT_MODEL
                     );
-                    PsiAnnotationMemberValue memberValue = componentModelAttribute == null ?
-                        null :
-                        componentModelAttribute.getDetachedValue();
-                    String componentModel = memberValue == null ?
-                        null :
-                        AnnotationUtil.getStringAttributeValue( memberValue );
+                    PsiAnnotationMemberValue memberValue;
+
+                    if (componentModelAttribute != null) {
+                        memberValue = componentModelAttribute.getDetachedValue();
+                    }
+                    else {
+                        memberValue = MapstructAnnotationUtils.findConfigValueFromMapperConfig( mapperAnnotation,
+                                COMPONENT_MODEL );
+                    }
+                    String componentModel = memberValue == null ? null :
+                            AnnotationUtil.getStringAttributeValue(  memberValue );
                     if ( componentModel != null && !componentModel.equals( "default" ) ) {
                         List<LocalQuickFix> fixes = new ArrayList<>(2);
-                        fixes.add(  createRemoveComponentModelFix( componentModelAttribute, mapperClass ) );
+                        if (componentModelAttribute != null) {
+                            fixes.add(  createRemoveComponentModelFix( componentModelAttribute, mapperClass ) );
+                        }
                         LocalQuickFix removeMappersFix = createRemoveMappersFix( expression );
                         if ( removeMappersFix != null ) {
                             fixes.add( removeMappersFix );

--- a/src/main/java/org/mapstruct/intellij/util/MapstructAnnotationUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructAnnotationUtils.java
@@ -567,22 +567,34 @@ public class MapstructAnnotationUtils {
 
     @NotNull
     private static ReportingPolicy getUnmappedTargetPolicyFromMapperConfig(@NotNull PsiAnnotation mapperAnnotation) {
+        PsiAnnotationMemberValue configValue = findConfigValueFromMapperConfig( mapperAnnotation,
+                UNMAPPED_TARGET_POLICY );
+        if (configValue == null) {
+            return ReportingPolicy.WARN;
+        }
+        return getUnmappedTargetPolicyPolicyFromAnnotation( configValue );
+    }
+
+    /**
+     * finds a property from a referenced mapper config class
+     * @param mapperAnnotation the @Mapper annotation from the current class
+     * @param name the name of the property tp find
+     * @return null if no mapper config class is used or no property with name is found.
+     */
+    @Nullable
+    public static PsiAnnotationMemberValue findConfigValueFromMapperConfig(@NotNull PsiAnnotation mapperAnnotation,
+                                                                           @NotNull String name) {
         PsiModifierListOwner mapperConfigReference = findMapperConfigReference( mapperAnnotation );
         if ( mapperConfigReference == null ) {
-            return ReportingPolicy.WARN;
+            return null;
         }
         PsiAnnotation mapperConfigAnnotation = mapperConfigReference.getAnnotation(
             MapstructUtil.MAPPER_CONFIG_ANNOTATION_FQN );
 
         if ( mapperConfigAnnotation == null ) {
-            return ReportingPolicy.WARN;
+            return null;
         }
-        PsiAnnotationMemberValue configValue =
-            mapperConfigAnnotation.findDeclaredAttributeValue( UNMAPPED_TARGET_POLICY );
-        if ( configValue == null ) {
-            return ReportingPolicy.WARN;
-        }
-        return getUnmappedTargetPolicyPolicyFromAnnotation( configValue );
+        return mapperConfigAnnotation.findDeclaredAttributeValue( name );
     }
 
 

--- a/src/test/java/org/mapstruct/intellij/bugs/_180/WrongUsageOfMappersFactoryFromConfigInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/bugs/_180/WrongUsageOfMappersFactoryFromConfigInspectionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.intellij.bugs._180;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import org.jetbrains.annotations.NotNull;
+import org.mapstruct.intellij.inspection.BaseInspectionTest;
+import org.mapstruct.intellij.inspection.WrongUsageOfMappersFactoryInspection;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author hduelme
+ */
+public class WrongUsageOfMappersFactoryFromConfigInspectionTest extends BaseInspectionTest {
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/bugs/_180";
+    }
+
+    @NotNull
+    @Override
+    protected Class<WrongUsageOfMappersFactoryInspection> getInspection() {
+        return WrongUsageOfMappersFactoryInspection.class;
+    }
+
+    public void testWrongUsageOfMappersFactoryFromConfig() {
+        doTest();
+        String testName = getTestName( false );
+        List<IntentionAction> allQuickFixes = myFixture.getAllQuickFixes();
+
+        assertThat( allQuickFixes )
+                .extracting( IntentionAction::getText )
+                .as( "Intent Text" )
+                .containsExactly(
+                        "Remove 'spring' componentModel from 'SpringConfigComponentModelOverrideMapper' @Mapper",
+                        "Remove usage of Mappers factory",
+                        "Remove usage of Mappers factory",
+                        "Remove usage of Mappers factory",
+                        "Remove usage of Mappers factory"
+                );
+        // Remove usage fix
+        myFixture.launchAction( allQuickFixes.get( 1 ) );
+        myFixture.launchAction( allQuickFixes.get( 2 ) );
+        myFixture.launchAction( allQuickFixes.get( 3 ) );
+        myFixture.launchAction( allQuickFixes.get( 4 ) );
+        myFixture.checkResultByFile( testName + "_after.java" );
+    }
+}

--- a/testData/bugs/_180/WrongUsageOfMappersFactoryFromConfig.java
+++ b/testData/bugs/_180/WrongUsageOfMappersFactoryFromConfig.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(config = DefaultConfigComponentModelMapper.DefaultConfig.class)
+interface DefaultConfigComponentModelMapper {
+
+    @MapperConfig(componentModel = "default")
+    interface  DefaultConfig {
+
+    }
+
+    DefaultConfigComponentModelMapper INSTANCE = Mappers.getMapper( DefaultConfigComponentModelMapper.class );
+
+    Target map(Source source);
+}
+
+@Mapper(config = SpringConfigComponentModelOverrideMapper.DefaultConfig.class, componentModel = "spring")
+interface SpringConfigComponentModelOverrideMapper {
+
+    @MapperConfig(componentModel = "default")
+    interface  DefaultConfig {
+
+    }
+
+    SpringConfigComponentModelOverrideMapper INSTANCE = <warning descr="Using Mappers factory with non default component model">Mappers.getMapper( SpringConfigComponentModelOverrideMapper.class )</warning>;
+
+    Target map(Source source);
+}
+
+@Mapper(config = SpringConfigComponentModelMapper.SpringConfig.class)
+interface SpringConfigComponentModelMapper {
+
+    @MapperConfig(componentModel = "spring")
+    interface SpringConfig {
+
+    }
+
+    SpringConfigComponentModelMapper INSTANCE = <warning descr="Using Mappers factory with non default component model">Mappers.getMapper( SpringConfigComponentModelMapper.class )</warning>;
+
+    Target map(Source source);
+}
+
+@Mapper(config = Jsr330ConfigComponentModelMapper.Jsr33Config.class, unmappedTargetPolicy = ReportingPolicy.ERROR)
+interface Jsr330ConfigComponentModelMapper {
+
+    @MapperConfig(componentModel = "jsr330")
+    interface Jsr33Config {
+
+    }
+
+    Jsr330ConfigComponentModelMapper INSTANCE = <warning descr="Using Mappers factory with non default component model">Mappers.getMapper( Jsr330ConfigComponentModelMapper.class )</warning>;
+
+    Target map(Source source);
+}
+
+@Mapper(config = CustomConfigComponentModelMapper.CustomConfig.class)
+interface CustomConfigComponentModelMapper {
+
+    @MapperConfig(componentModel = "custom")
+    interface CustomConfig {
+
+    }
+
+    CustomConfigComponentModelMapper INSTANCE = <warning descr="Using Mappers factory with non default component model">Mappers.getMapper( CustomConfigComponentModelMapper.class )</warning>;
+
+    Target map(Source source);
+}
+
+@Mapper(config = DefaultConfigComponentModelOverrideMapper.SpringConfig.class, componentModel = "default")
+interface DefaultConfigComponentModelOverrideMapper {
+
+    @MapperConfig(componentModel = "spring")
+    interface SpringConfig {
+
+    }
+
+    DefaultConfigComponentModelOverrideMapper INSTANCE = Mappers.getMapper( DefaultConfigComponentModelOverrideMapper.class );
+
+    Target map(Source source);
+}
+
+class Source {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}
+
+class Target {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/testData/bugs/_180/WrongUsageOfMappersFactoryFromConfig_after.java
+++ b/testData/bugs/_180/WrongUsageOfMappersFactoryFromConfig_after.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(config = DefaultConfigComponentModelMapper.DefaultConfig.class)
+interface DefaultConfigComponentModelMapper {
+
+    @MapperConfig(componentModel = "default")
+    interface  DefaultConfig {
+
+    }
+
+    DefaultConfigComponentModelMapper INSTANCE = Mappers.getMapper( DefaultConfigComponentModelMapper.class );
+
+    Target map(Source source);
+}
+
+@Mapper(config = SpringConfigComponentModelOverrideMapper.DefaultConfig.class, componentModel = "spring")
+interface SpringConfigComponentModelOverrideMapper {
+
+    @MapperConfig(componentModel = "default")
+    interface  DefaultConfig {
+
+    }
+
+    Target map(Source source);
+}
+
+@Mapper(config = SpringConfigComponentModelMapper.SpringConfig.class)
+interface SpringConfigComponentModelMapper {
+
+    @MapperConfig(componentModel = "spring")
+    interface SpringConfig {
+
+    }
+
+    Target map(Source source);
+}
+
+@Mapper(config = Jsr330ConfigComponentModelMapper.Jsr33Config.class, unmappedTargetPolicy = ReportingPolicy.ERROR)
+interface Jsr330ConfigComponentModelMapper {
+
+    @MapperConfig(componentModel = "jsr330")
+    interface Jsr33Config {
+
+    }
+
+    Target map(Source source);
+}
+
+@Mapper(config = CustomConfigComponentModelMapper.CustomConfig.class)
+interface CustomConfigComponentModelMapper {
+
+    @MapperConfig(componentModel = "custom")
+    interface CustomConfig {
+
+    }
+
+    Target map(Source source);
+}
+
+@Mapper(config = DefaultConfigComponentModelOverrideMapper.SpringConfig.class, componentModel = "default")
+interface DefaultConfigComponentModelOverrideMapper {
+
+    @MapperConfig(componentModel = "spring")
+    interface SpringConfig {
+
+    }
+
+    DefaultConfigComponentModelOverrideMapper INSTANCE = Mappers.getMapper( DefaultConfigComponentModelOverrideMapper.class );
+
+    Target map(Source source);
+}
+
+class Source {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}
+
+class Target {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
I added support to read the `componentModel` from a `MapperConfig` for `WrongUsageOfMappersFactoryInspection` see #180 .
I only added the quickfix to remove `Mappers` usage. I think it is more intuitive to not write to other files for this. If we want to support this we must ensure that we could write to the `MapperConfig` (could be provided as a dependency for example).