### PR TITLE
fix issue 194 source property with same name exists

### DIFF
--- a/src/main/java/org/mapstruct/intellij/inspection/NoSourcePropertyDefinedInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/NoSourcePropertyDefinedInspection.java
@@ -11,11 +11,13 @@ import com.intellij.psi.PsiAnnotationMemberValue;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiLiteralExpression;
 import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiNameValuePair;
 import com.intellij.psi.impl.source.tree.java.PsiAnnotationParamListImpl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mapstruct.intellij.MapStructBundle;
 import org.mapstruct.intellij.util.MapstructUtil;
+import org.mapstruct.intellij.util.SourceUtils;
 
 /**
  * Inspection that checks if inside a @Mapping at least one source property is defined
@@ -27,17 +29,26 @@ public class NoSourcePropertyDefinedInspection extends MappingAnnotationInspecti
     @Override
     void visitMappingAnnotation( @NotNull ProblemsHolder problemsHolder, @NotNull PsiAnnotation psiAnnotation,
                                  @NotNull MappingAnnotation mappingAnnotation ) {
-        if (mappingAnnotation.hasNoSourceProperties() && !isIgnoreByDefaultEnabled( psiAnnotation ) ) {
+        PsiNameValuePair targetProperty = mappingAnnotation.getTargetProperty();
+        PsiMethod annotatedMethod = getAnnotatedMethod( psiAnnotation );
+        if (targetProperty != null && annotatedMethod != null && mappingAnnotation.hasNoSourceProperties()
+                && !isIgnoreByDefaultEnabled( annotatedMethod ) &&
+                !hasMatchingSourceProperty( annotatedMethod, targetProperty ) ) {
             problemsHolder.registerProblem( psiAnnotation,
                     MapStructBundle.message( "inspection.no.source.property" ) );
         }
     }
 
-    private static boolean isIgnoreByDefaultEnabled(@NotNull PsiAnnotation psiAnnotation) {
-        PsiMethod annotatedMethod = getAnnotatedMethod( psiAnnotation );
-        if (annotatedMethod == null) {
+    private boolean hasMatchingSourceProperty( @NotNull PsiMethod annotatedMethod,
+                                               @NotNull PsiNameValuePair targetProperty ) {
+        String targetValue = targetProperty.getLiteralValue();
+        if (targetValue == null) {
             return false;
         }
+        return  SourceUtils.findAllSourceProperties( annotatedMethod ).contains( targetValue );
+    }
+
+    private static boolean isIgnoreByDefaultEnabled( @NotNull PsiMethod annotatedMethod ) {
         PsiAnnotation beanMappingAnnotation = annotatedMethod.getAnnotation( MapstructUtil.BEAN_MAPPING_FQN );
         if (beanMappingAnnotation == null) {
             return false;

--- a/src/test/java/org/mapstruct/intellij/bugs/_194/NoSourcePropertyDefinedSourcePropertyWithSameNameExistsInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/bugs/_194/NoSourcePropertyDefinedSourcePropertyWithSameNameExistsInspectionTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.intellij.bugs._194;
+
+import org.jetbrains.annotations.NotNull;
+import org.mapstruct.intellij.inspection.BaseInspectionTest;
+import org.mapstruct.intellij.inspection.NoSourcePropertyDefinedInspection;
+
+/**
+ * @author hduelme
+ */
+public class NoSourcePropertyDefinedSourcePropertyWithSameNameExistsInspectionTest extends BaseInspectionTest {
+
+    @Override
+    protected @NotNull Class<NoSourcePropertyDefinedInspection> getInspection() {
+        return NoSourcePropertyDefinedInspection.class;
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/bugs/_194";
+    }
+
+    public void testNoSourcePropertyDefinedSourcePropertyWithSameNameExists() {
+        doTest();
+    }
+}

--- a/testData/bugs/_194/NoSourcePropertyDefinedSourcePropertyWithSameNameExists.java
+++ b/testData/bugs/_194/NoSourcePropertyDefinedSourcePropertyWithSameNameExists.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+class Source {
+
+    private String testName;
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public void setTestName(String testName) {
+        this.testName = testName;
+    }
+}
+
+class Target {
+
+    private String testName;
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public void setTestName(String testName) {
+        this.testName = testName;
+    }
+}
+
+@Mapper
+interface SingleMappingMapper {
+
+   @Mapping(target = "testName")
+    Target map(Source source);
+}
+
+@Mapper
+interface SingleMappingsMapper {
+
+    @Mappings({
+        @Mapping(target = "testName")
+    })
+    Target map(Source source);
+}
+


### PR DESCRIPTION
I think I found the root cause of #194. As show in the example of #196 the plugin currently doesn't check if there exists a source property with the same name.

Fixes #194 