### PR TITLE
upgrade to Java 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - { jdk: 11, idea: 2022.1 }
           - { jdk: 17, idea: 2022.2 }
           - { jdk: 17, idea: 2022.3 }
           - { jdk: 17, idea: 2023.1 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'license'
 apply plugin: 'checkstyle'
 apply plugin: 'jacoco'
 
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 17
+targetCompatibility = 17
 
 repositories {
     mavenLocal()

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-ideaVersion = 2022.1
+ideaVersion = 2022.2
 ideaType = IC
 sources = true
 isEAP = false

--- a/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructBaseReference.java
+++ b/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructBaseReference.java
@@ -170,8 +170,8 @@ abstract class MapstructBaseReference extends BaseReference {
         ReferenceCreator<T> creator, boolean supportsNested) {
         String targetValue;
         Function<String, TextRange> rangeCreator;
-        if ( psiElement instanceof PsiReferenceExpression ) {
-            PsiElement resolvedPsiElement = ( (PsiReferenceExpression) psiElement ).resolve();
+        if ( psiElement instanceof PsiReferenceExpression psiReferenceExpression ) {
+            PsiElement resolvedPsiElement = psiReferenceExpression.resolve();
 
             PsiLiteralExpression expression = PsiTreeUtil.findChildOfType(
                 resolvedPsiElement,

--- a/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructSourceReference.java
+++ b/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructSourceReference.java
@@ -125,17 +125,17 @@ class MapstructSourceReference extends MapstructBaseReference {
     PsiType resolvedType() {
         PsiElement element = resolve();
 
-        if ( element instanceof PsiMethod ) {
-            return ( (PsiMethod) element ).getReturnType();
+        if ( element instanceof PsiMethod psiMethod ) {
+            return psiMethod.getReturnType();
         }
-        else if ( element instanceof PsiParameter ) {
-            return ( (PsiParameter) element ).getType();
+        else if ( element instanceof PsiParameter psiParameter ) {
+            return psiParameter.getType();
         }
-        else if ( element instanceof PsiRecordComponent ) {
-            return ( (PsiRecordComponent) element ).getType();
+        else if ( element instanceof PsiRecordComponent psiRecordComponent ) {
+            return psiRecordComponent.getType();
         }
-        else if ( element instanceof PsiField ) {
-            return ( (PsiField) element ).getType();
+        else if ( element instanceof PsiField psiField ) {
+            return psiField.getType();
         }
 
         return null;
@@ -160,11 +160,11 @@ class MapstructSourceReference extends MapstructBaseReference {
     }
 
     private static PsiType memberPsiType(PsiElement psiMember) {
-        if ( psiMember instanceof PsiMethod ) {
-            return ( (PsiMethod) psiMember ).getReturnType();
+        if ( psiMember instanceof PsiMethod psiMemberMethod ) {
+            return psiMemberMethod.getReturnType();
         }
-        else if ( psiMember instanceof PsiVariable ) {
-            return ( (PsiVariable) psiMember ).getType();
+        else if ( psiMember instanceof PsiVariable psiMemberVariable ) {
+            return psiMemberVariable.getType();
         }
         else {
             return null;

--- a/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructTargetReference.java
+++ b/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructTargetReference.java
@@ -191,17 +191,17 @@ class MapstructTargetReference extends MapstructBaseReference {
     PsiType resolvedType() {
         PsiElement element = resolve();
 
-        if ( element instanceof PsiMethod ) {
-            return firstParameterPsiType( (PsiMethod) element );
+        if ( element instanceof PsiMethod psiMethod ) {
+            return firstParameterPsiType( psiMethod );
         }
-        else if ( element instanceof PsiParameter ) {
-            return ( (PsiParameter) element ).getType();
+        else if ( element instanceof PsiParameter psiParameter ) {
+            return psiParameter.getType();
         }
-        else if ( element instanceof PsiRecordComponent ) {
-            return ( (PsiRecordComponent) element ).getType();
+        else if ( element instanceof PsiRecordComponent psiRecordComponent ) {
+            return psiRecordComponent.getType();
         }
-        else if ( element instanceof PsiField ) {
-            return ( (PsiField) element ).getType();
+        else if ( element instanceof PsiField psiField ) {
+            return psiField.getType();
         }
 
         return null;
@@ -217,11 +217,11 @@ class MapstructTargetReference extends MapstructBaseReference {
     }
 
     private static PsiType memberPsiType(PsiElement psiMember) {
-        if ( psiMember instanceof PsiMethod ) {
-            return firstParameterPsiType( (PsiMethod) psiMember );
+        if ( psiMember instanceof PsiMethod psiMemberMethod ) {
+            return firstParameterPsiType( psiMemberMethod );
         }
-        else if ( psiMember instanceof PsiVariable ) {
-            return ( (PsiVariable) psiMember ).getType();
+        else if ( psiMember instanceof PsiVariable psiMemberVariable ) {
+            return psiMemberVariable.getType();
         }
         else {
             return null;

--- a/src/main/java/org/mapstruct/intellij/expression/JavaExpressionInjector.java
+++ b/src/main/java/org/mapstruct/intellij/expression/JavaExpressionInjector.java
@@ -70,11 +70,10 @@ public class JavaExpressionInjector implements MultiHostInjector {
 
     private void appendType(@NotNull StringBuilder sb, @NotNull Set<String> imports, @NotNull PsiType type) {
         importIfNecessary( PsiUtil.resolveClassInType( type ), imports );
-        if ( !( type instanceof PsiClassType ) ) {
+        if ( !( type instanceof PsiClassType ct ) ) {
             sb.append( type.getPresentableText() );
             return;
         }
-        PsiClassType ct = (PsiClassType) type;
         sb.append( ct.getName() );
         PsiType[] typeParameters = ct.getParameters();
         if ( typeParameters.length == 0 ) {
@@ -178,18 +177,18 @@ public class JavaExpressionInjector implements MultiHostInjector {
                             attributeValue );
                         if ( references.length > 0 ) {
                             PsiElement resolved = references[0].resolve();
-                            if ( resolved instanceof PsiMethod ) {
+                            if ( resolved instanceof PsiMethod resolvedPsiMethod ) {
                                 PsiParameter[] psiParameters =
-                                        ((PsiMethod) resolved).getParameterList().getParameters();
+                                        resolvedPsiMethod.getParameterList().getParameters();
                                 if ( psiParameters.length > 0) {
                                     targetType = psiParameters[0].getType();
                                 }
                             }
-                            else if ( resolved instanceof PsiParameter ) {
-                                targetType = ( (PsiParameter) resolved ).getType();
+                            else if ( resolved instanceof PsiParameter resolvedPsiParameter ) {
+                                targetType = resolvedPsiParameter.getType();
                             }
-                            else if ( resolved instanceof PsiField) {
-                                targetType = ( (PsiField) resolved ).getType();
+                            else if ( resolved instanceof PsiField resolvedPsiField ) {
+                                targetType = resolvedPsiField.getType();
                             }
                         }
                     }
@@ -259,12 +258,13 @@ public class JavaExpressionInjector implements MultiHostInjector {
                         for ( PsiAnnotationMemberValue importValue : AnnotationUtil.arrayAttributeValues(
                             attribute.getValue() ) ) {
 
-                            if ( importValue instanceof PsiJavaCodeReferenceElement ) {
-                                imports.add( ( (PsiJavaCodeReferenceElement) importValue ).getQualifiedName() );
+                            if ( importValue instanceof PsiJavaCodeReferenceElement importJavaCodeReferenceElement ) {
+                                imports.add( importJavaCodeReferenceElement.getQualifiedName() );
                             }
-                            else if ( importValue instanceof PsiClassObjectAccessExpression ) {
+                            else if ( importValue instanceof PsiClassObjectAccessExpression
+                                    importClassObjectAccessExpression ) {
                                 PsiJavaCodeReferenceElement referenceElement =
-                                    ( (PsiClassObjectAccessExpression) importValue ).getOperand()
+                                        importClassObjectAccessExpression.getOperand()
                                         .getInnermostComponentReferenceElement();
                                 if ( referenceElement != null ) {
                                     imports.add( referenceElement.getQualifiedName() );

--- a/src/main/java/org/mapstruct/intellij/inspection/FromMapMappingMapTypeInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/FromMapMappingMapTypeInspection.java
@@ -133,8 +133,7 @@ public class FromMapMappingMapTypeInspection extends InspectionBase {
                 if (!super.isAvailable( project, file, startElement, endElement ) ) {
                     return false;
                 }
-                if (startElement instanceof PsiParameter) {
-                    PsiParameter parameter = (PsiParameter) startElement;
+                if (startElement instanceof PsiParameter parameter) {
                     PsiType[] parameters = getGenericTypes( parameter );
                     return parameters != null && parameters.length == 0;
                 }
@@ -179,8 +178,7 @@ public class FromMapMappingMapTypeInspection extends InspectionBase {
                 if (!super.isAvailable( project, file, startElement, endElement ) ) {
                     return false;
                 }
-                if (startElement instanceof PsiParameter) {
-                    PsiParameter parameter = (PsiParameter) startElement;
+                if (startElement instanceof PsiParameter parameter) {
                     PsiType[] parameters = getGenericTypes( parameter );
                     if (parameters == null || parameters.length != 2) {
                         return false;

--- a/src/main/java/org/mapstruct/intellij/inspection/JavaExpressionUnnecessaryWhitespacesInspector.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/JavaExpressionUnnecessaryWhitespacesInspector.java
@@ -80,8 +80,7 @@ public class JavaExpressionUnnecessaryWhitespacesInspector extends MappingAnnota
         @Override
         public void invoke(@NotNull Project project, @NotNull PsiFile psiFile, @NotNull PsiElement psiElement,
                            @NotNull PsiElement psiElement1) {
-            if (psiElement instanceof PsiNameValuePair) {
-                PsiNameValuePair psiNameValuePair = (PsiNameValuePair) psiElement;
+            if (psiElement instanceof PsiNameValuePair psiNameValuePair) {
                 PsiAnnotationMemberValue value = psiNameValuePair.getValue();
                 if (value != null) {
                     String text = value.getText();
@@ -102,10 +101,10 @@ public class JavaExpressionUnnecessaryWhitespacesInspector extends MappingAnnota
             if ( !super.isAvailable( project, file, startElement, endElement ) ) {
                 return false;
             }
-            if ( !(startElement instanceof PsiNameValuePair ) ) {
+            if ( !(startElement instanceof PsiNameValuePair startPsiNameValuePair ) ) {
                 return false;
             }
-            return ((PsiNameValuePair) startElement).getValue() != null;
+            return startPsiNameValuePair.getValue() != null;
         }
     }
 
@@ -126,8 +125,7 @@ public class JavaExpressionUnnecessaryWhitespacesInspector extends MappingAnnota
         @Override
         public void invoke(@NotNull Project project, @NotNull PsiFile psiFile, @NotNull PsiElement psiElement,
                            @NotNull PsiElement psiElement1) {
-            if (psiElement instanceof PsiNameValuePair) {
-                PsiNameValuePair psiNameValuePair = (PsiNameValuePair) psiElement;
+            if (psiElement instanceof PsiNameValuePair psiNameValuePair) {
                 PsiAnnotationMemberValue value = psiNameValuePair.getValue();
                 if (value != null) {
                     String text = value.getText();
@@ -148,10 +146,10 @@ public class JavaExpressionUnnecessaryWhitespacesInspector extends MappingAnnota
             if ( !super.isAvailable( project, file, startElement, endElement ) ) {
                 return false;
             }
-            if ( !(startElement instanceof PsiNameValuePair ) ) {
+            if ( !(startElement instanceof PsiNameValuePair startPsiNameValuePair ) ) {
                 return false;
             }
-            return ((PsiNameValuePair) startElement).getValue() != null;
+            return startPsiNameValuePair.getValue() != null;
         }
     }
 }

--- a/src/main/java/org/mapstruct/intellij/inspection/MappingAnnotationInspectionBase.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/MappingAnnotationInspectionBase.java
@@ -44,9 +44,8 @@ public abstract class MappingAnnotationInspectionBase extends InspectionBase {
                 MappingAnnotation mappingAnnotation = new MappingAnnotation();
                 for (JvmAnnotationAttribute annotationAttribute : annotation.getAttributes()) {
                     // exclude not written attributes. They result in a syntax error
-                    if (annotationAttribute instanceof PsiNameValuePair
+                    if (annotationAttribute instanceof PsiNameValuePair nameValuePair
                             && annotationAttribute.getAttributeValue() != null) {
-                        PsiNameValuePair nameValuePair = (PsiNameValuePair) annotationAttribute;
                         switch (nameValuePair.getAttributeName()) {
                             case "target" :
                                 mappingAnnotation.setTargetProperty( nameValuePair );
@@ -285,8 +284,7 @@ public abstract class MappingAnnotationInspectionBase extends InspectionBase {
         @Override
         public void invoke( @NotNull Project project, @NotNull PsiFile file, @NotNull PsiElement startElement,
                             @NotNull PsiElement endElement ) {
-            if (endElement instanceof PsiNameValuePair) {
-                PsiNameValuePair end = (PsiNameValuePair) endElement;
+            if (endElement instanceof PsiNameValuePair end) {
                 PsiAnnotationParamListImpl parent = (PsiAnnotationParamListImpl) end.getParent();
                 PsiElement parent1 = parent.getParent();
 

--- a/src/main/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/WrongUsageOfMappersFactoryInspection.java
@@ -66,10 +66,9 @@ public class WrongUsageOfMappersFactoryInspection extends InspectionBase {
             if ( MAPPERS_FACTORY_CALL_MATCHER.test( expression ) ) {
                 PsiExpression argument = PsiUtil.skipParenthesizedExprDown( expression.getArgumentList()
                     .getExpressions()[0] );
-                if ( !( argument instanceof PsiClassObjectAccessExpression ) ) {
+                if ( !( argument instanceof PsiClassObjectAccessExpression classObjectAccessExpression ) ) {
                     return;
                 }
-                PsiClassObjectAccessExpression classObjectAccessExpression = (PsiClassObjectAccessExpression) argument;
                 PsiJavaCodeReferenceElement referenceElement = classObjectAccessExpression.getOperand()
                     .getInnermostComponentReferenceElement();
 
@@ -79,11 +78,10 @@ public class WrongUsageOfMappersFactoryInspection extends InspectionBase {
 
                 PsiElement mapperElement = referenceElement.resolve();
 
-                if ( !( mapperElement instanceof PsiClass ) ) {
+                if ( !( mapperElement instanceof PsiClass mapperClass ) ) {
                     return;
                 }
 
-                PsiClass mapperClass = (PsiClass) mapperElement;
                 PsiAnnotation mapperAnnotation = mapperClass.getAnnotation( MapstructUtil.MAPPER_ANNOTATION_FQN );
                 if ( mapperAnnotation == null ) {
                     List<LocalQuickFix> fixes = new ArrayList<>(2);
@@ -165,9 +163,9 @@ public class WrongUsageOfMappersFactoryInspection extends InspectionBase {
 
     private static LocalQuickFix createRemoveMappersFix(@NotNull PsiMethodCallExpression methodCallExpression) {
         PsiElement parent = methodCallExpression.getParent();
-        if ( parent instanceof PsiVariable ) {
+        if ( parent instanceof PsiVariable parentPsiVariable ) {
 
-                return new RemoveMappersFix( (PsiVariable) parent );
+                return new RemoveMappersFix( parentPsiVariable );
         }
 
         return null;

--- a/src/main/java/org/mapstruct/intellij/util/SourceUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/SourceUtils.java
@@ -114,11 +114,11 @@ public class SourceUtils {
 
     public static Map<String, Pair<? extends PsiElement, PsiSubstitutor>> publicReadAccessors(
         @Nullable PsiElement psiElement) {
-        if ( psiElement instanceof PsiMethod ) {
-            return publicReadAccessors( ( (PsiMethod) psiElement ).getReturnType() );
+        if ( psiElement instanceof PsiMethod psiMethod ) {
+            return publicReadAccessors( psiMethod.getReturnType() );
         }
-        else if ( psiElement instanceof PsiParameter ) {
-            return publicReadAccessors( ( (PsiParameter) psiElement ).getType() );
+        else if ( psiElement instanceof PsiParameter psiParameter ) {
+            return publicReadAccessors( psiParameter.getType() );
         }
 
         return Collections.emptyMap();

--- a/src/main/java/org/mapstruct/intellij/util/TargetUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/TargetUtils.java
@@ -179,8 +179,8 @@ public class TargetUtils {
     private static Optional<Boolean> findDisabledBuilder(@Nullable PsiAnnotation requestedAnnotation) {
         if ( requestedAnnotation != null ) {
             PsiAnnotationMemberValue builderValue = requestedAnnotation.findDeclaredAttributeValue( "builder" );
-            if ( builderValue instanceof PsiAnnotation ) {
-                Boolean disableBuilder = getBooleanAttributeValue( (PsiAnnotation) builderValue, "disableBuilder" );
+            if ( builderValue instanceof PsiAnnotation builderAnnotation ) {
+                Boolean disableBuilder = getBooleanAttributeValue( builderAnnotation, "disableBuilder" );
                 return Optional.ofNullable( disableBuilder );
             }
         }

--- a/src/main/java/org/mapstruct/intellij/util/patterns/KtValueArgumentNamePattern.java
+++ b/src/main/java/org/mapstruct/intellij/util/patterns/KtValueArgumentNamePattern.java
@@ -30,8 +30,8 @@ public class KtValueArgumentNamePattern extends PsiElementPattern<KtValueArgumen
             @Nullable
             @Override
             public String getPropertyValue(@NotNull Object o) {
-                if ( o instanceof KtValueArgumentName ) {
-                    return ( (KtValueArgumentName) o ).getAsName().getIdentifier();
+                if ( o instanceof KtValueArgumentName ktValueArgumentName ) {
+                    return ktValueArgumentName.getAsName().getIdentifier();
                 }
                 return null;
             }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -24,7 +24,7 @@
   <vendor url="https://www.mapstruct.org">MapStruct</vendor>
 
   <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-  <idea-version since-build="221"/>
+  <idea-version since-build="222"/>
 
   <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
        on how to target different products -->

--- a/src/test/java/org/mapstruct/intellij/ValueMappingCompletionTestCase.java
+++ b/src/test/java/org/mapstruct/intellij/ValueMappingCompletionTestCase.java
@@ -22,57 +22,63 @@ import static org.mapstruct.intellij.testutil.TestUtils.createField;
 public class ValueMappingCompletionTestCase extends MapstructBaseCompletionTestCase {
 
     @Language("JAVA")
-    private static final String SOURCE_VALUE_MAPPING_DYNAMIC = "import org.mapstruct.Mapper;\n" +
-        "import org.mapstruct.ValueMapping;\n" +
-        "import org.mapstruct.example.ExternalRoofType;\n" +
-        "import org.mapstruct.example.RoofType;\n" +
-        "\n" +
-        "@Mapper\n" +
-        "public interface RoofTypeMapper {\n" +
-        "\n" +
-        "    %s" +
-        "    ExternalRoofType map(RoofType type);\n" +
-        "}";
+    private static final String SOURCE_VALUE_MAPPING_DYNAMIC = """
+            import org.mapstruct.Mapper;
+            import org.mapstruct.ValueMapping;
+            import org.mapstruct.example.ExternalRoofType;
+            import org.mapstruct.example.RoofType;
+
+            @Mapper
+            public interface RoofTypeMapper {
+
+                %s\
+                ExternalRoofType map(RoofType type);
+            }""";
 
     @Language("JAVA")
-    private static final String SOURCE_VALUE_MAPPINGS_DYNAMIC = "import org.mapstruct.Mapper;\n" +
-        "import org.mapstruct.ValueMapping;\n" +
-        "import org.mapstruct.ValueMappings;\n" +
-        "import org.mapstruct.example.ExternalRoofType;\n" +
-        "import org.mapstruct.example.RoofType;\n" +
-        "\n" +
-        "@Mapper\n" +
-        "public interface RoofTypeMapper {\n" +
-        "\n" +
-        "    @ValueMappings({\n%s\n})\n" +
-        "    ExternalRoofType map(RoofType type);\n" +
-        "}";
+    private static final String SOURCE_VALUE_MAPPINGS_DYNAMIC = """
+            import org.mapstruct.Mapper;
+            import org.mapstruct.ValueMapping;
+            import org.mapstruct.ValueMappings;
+            import org.mapstruct.example.ExternalRoofType;
+            import org.mapstruct.example.RoofType;
+
+            @Mapper
+            public interface RoofTypeMapper {
+
+                @ValueMappings({
+            %s
+            })
+                ExternalRoofType map(RoofType type);
+            }""";
 
     @Language("JAVA")
-    private static final String SOURCE_VALUE_MAPPING = "import org.mapstruct.Mapper;\n" +
-        "import org.mapstruct.ValueMapping;\n" +
-        "import org.mapstruct.example.ExternalRoofType;\n" +
-        "import org.mapstruct.example.RoofType;\n" +
-        "\n" +
-        "@Mapper\n" +
-        "public interface RoofTypeMapper {\n" +
-        "\n" +
-        "    @ValueMapping(source = \"<caret>%s\", target = \"STANDARD\")\n" +
-        "    ExternalRoofType map(RoofType type);\n" +
-        "}";
+    private static final String SOURCE_VALUE_MAPPING = """
+            import org.mapstruct.Mapper;
+            import org.mapstruct.ValueMapping;
+            import org.mapstruct.example.ExternalRoofType;
+            import org.mapstruct.example.RoofType;
+
+            @Mapper
+            public interface RoofTypeMapper {
+
+                @ValueMapping(source = "<caret>%s", target = "STANDARD")
+                ExternalRoofType map(RoofType type);
+            }""";
 
     @Language("JAVA")
-    private static final String TARGET_VALUE_MAPPING = "import org.mapstruct.Mapper;\n" +
-        "import org.mapstruct.ValueMapping;\n" +
-        "import org.mapstruct.example.ExternalRoofType;\n" +
-        "import org.mapstruct.example.RoofType;\n" +
-        "\n" +
-        "@Mapper\n" +
-        "public interface RoofTypeMapper {\n" +
-        "\n" +
-        "    @ValueMapping(source = \"NORMAL\", target = \"<caret>%s\")\n" +
-        "    ExternalRoofType map(RoofType type);\n" +
-        "}";
+    private static final String TARGET_VALUE_MAPPING = """
+            import org.mapstruct.Mapper;
+            import org.mapstruct.ValueMapping;
+            import org.mapstruct.example.ExternalRoofType;
+            import org.mapstruct.example.RoofType;
+
+            @Mapper
+            public interface RoofTypeMapper {
+
+                @ValueMapping(source = "NORMAL", target = "<caret>%s")
+                ExternalRoofType map(RoofType type);
+            }""";
 
     @Override
     protected String getTestDataPath() {
@@ -112,8 +118,10 @@ public class ValueMappingCompletionTestCase extends MapstructBaseCompletionTestC
     public void testSourceValueMappingWithExisting() {
         String source = String.format(
             SOURCE_VALUE_MAPPING_DYNAMIC,
-            "@ValueMapping(source = \"GAMBREL\", target = \"NORMAL\")\n" +
-                "@ValueMapping(source = \"<caret>%s\", target = \"STANDARD\")\n"
+                """
+                        @ValueMapping(source = "GAMBREL", target = "NORMAL")
+                        @ValueMapping(source = "<caret>%s", target = "STANDARD")
+                        """
         );
         myFixture.configureByText( JavaFileType.INSTANCE, source );
         complete();
@@ -138,8 +146,10 @@ public class ValueMappingCompletionTestCase extends MapstructBaseCompletionTestC
     public void testSourceValueMappingsWithExisting() {
         String source = String.format(
             SOURCE_VALUE_MAPPINGS_DYNAMIC,
-            "@ValueMapping(source = \"GAMBREL\", target = \"NORMAL\"),\n" +
-                "@ValueMapping(source = \"<caret>%s\", target = \"STANDARD\")\n"
+                """
+                        @ValueMapping(source = "GAMBREL", target = "NORMAL"),
+                        @ValueMapping(source = "<caret>%s", target = "STANDARD")
+                        """
         );
         myFixture.configureByText( JavaFileType.INSTANCE, source );
         complete();
@@ -164,11 +174,13 @@ public class ValueMappingCompletionTestCase extends MapstructBaseCompletionTestC
     public void testSourceValueMappingAllValuesAlreadyMapped() {
         String source = String.format(
             SOURCE_VALUE_MAPPING_DYNAMIC,
-            "@ValueMapping(source = \"OPEN\", target = \"NORMAL\")\n" +
-                "@ValueMapping(source = \"BOX\", target = \"NORMAL\")\n" +
-                "@ValueMapping(source = \"GAMBREL\", target = \"NORMAL\")\n" +
-                "@ValueMapping(source = \"NORMAL\", target = \"NORMAL\")\n" +
-                "@ValueMapping(source = \"<caret>%s\", target = \"STANDARD\")\n"
+                """
+                        @ValueMapping(source = "OPEN", target = "NORMAL")
+                        @ValueMapping(source = "BOX", target = "NORMAL")
+                        @ValueMapping(source = "GAMBREL", target = "NORMAL")
+                        @ValueMapping(source = "NORMAL", target = "NORMAL")
+                        @ValueMapping(source = "<caret>%s", target = "STANDARD")
+                        """
         );
         myFixture.configureByText( JavaFileType.INSTANCE, source );
         complete();
@@ -185,11 +197,13 @@ public class ValueMappingCompletionTestCase extends MapstructBaseCompletionTestC
     public void testSourceValueMappingsAllValuesAlreadyMapped() {
         String source = String.format(
             SOURCE_VALUE_MAPPINGS_DYNAMIC,
-            "@ValueMapping(source = \"OPEN\", target = \"NORMAL\"),\n" +
-                "@ValueMapping(source = \"BOX\", target = \"NORMAL\"),\n" +
-                "@ValueMapping(source = \"GAMBREL\", target = \"NORMAL\"),\n" +
-                "@ValueMapping(source = \"NORMAL\", target = \"NORMAL\"),\n" +
-                "@ValueMapping(source = \"<caret>%s\", target = \"STANDARD\")\n"
+                """
+                        @ValueMapping(source = "OPEN", target = "NORMAL"),
+                        @ValueMapping(source = "BOX", target = "NORMAL"),
+                        @ValueMapping(source = "GAMBREL", target = "NORMAL"),
+                        @ValueMapping(source = "NORMAL", target = "NORMAL"),
+                        @ValueMapping(source = "<caret>%s", target = "STANDARD")
+                        """
         );
         myFixture.configureByText( JavaFileType.INSTANCE, source );
         complete();

--- a/src/test/java/org/mapstruct/intellij/expression/JavaExpressionInjectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/expression/JavaExpressionInjectionTest.java
@@ -354,20 +354,21 @@ public class JavaExpressionInjectionTest extends MapstructBaseCompletionTestCase
         String mapper = formatMapper( CAR_MAPPER, mapping, "imports = java.util.Collections.class" );
         configureMapperByText( mapper );
 
-        assertJavaFragment( "import CarMapper;\n" +
-            "import java.util.Collections;\n" +
-            "import org.example.dto.Car;\n" +
-            "\n" +
-            "@SuppressWarnings(\"unused\")\n" +
-            "abstract class CarMapperImpl\n" +
-            "    implements CarMapper {\n" +
-            "\n" +
-            "    String __test__(\n" +
-            "        Car car\n" +
-            "    ) {\n" +
-            "        return Collections;\n" +
-            "    }\n" +
-            "}" );
+        assertJavaFragment( """
+                import CarMapper;
+                import java.util.Collections;
+                import org.example.dto.Car;
+
+                @SuppressWarnings("unused")
+                abstract class CarMapperImpl
+                    implements CarMapper {
+
+                    String __test__(
+                        Car car
+                    ) {
+                        return Collections;
+                    }
+                }""" );
 
     }
 
@@ -383,20 +384,21 @@ public class JavaExpressionInjectionTest extends MapstructBaseCompletionTestCase
         String mapper = formatMapper( CAR_MAPPER, mapping, "imports = org.example.dto.Utils.class" );
         configureMapperByText( mapper );
 
-        assertJavaFragment( "import CarMapper;\n" +
-            "import org.example.dto.Car;\n" +
-            "import org.example.dto.Utils;\n" +
-            "\n" +
-            "@SuppressWarnings(\"unused\")\n" +
-            "abstract class CarMapperImpl\n" +
-            "    implements CarMapper {\n" +
-            "\n" +
-            "    String __test__(\n" +
-            "        Car car\n" +
-            "    ) {\n" +
-            "        return Utils;\n" +
-            "    }\n" +
-            "}" );
+        assertJavaFragment( """
+                import CarMapper;
+                import org.example.dto.Car;
+                import org.example.dto.Utils;
+
+                @SuppressWarnings("unused")
+                abstract class CarMapperImpl
+                    implements CarMapper {
+
+                    String __test__(
+                        Car car
+                    ) {
+                        return Utils;
+                    }
+                }""" );
     }
 
     public void testExpressionWithMapperWithoutImports() {
@@ -411,19 +413,20 @@ public class JavaExpressionInjectionTest extends MapstructBaseCompletionTestCase
         String mapper = formatMapper( CAR_MAPPER, mapping );
         configureMapperByText( mapper );
 
-        assertJavaFragment( "import CarMapper;\n" +
-            "import org.example.dto.Car;\n" +
-            "\n" +
-            "@SuppressWarnings(\"unused\")\n" +
-            "abstract class CarMapperImpl\n" +
-            "    implements CarMapper {\n" +
-            "\n" +
-            "    String __test__(\n" +
-            "        Car car\n" +
-            "    ) {\n" +
-            "        return Collections;\n" +
-            "    }\n" +
-            "}" );
+        assertJavaFragment( """
+                import CarMapper;
+                import org.example.dto.Car;
+
+                @SuppressWarnings("unused")
+                abstract class CarMapperImpl
+                    implements CarMapper {
+
+                    String __test__(
+                        Car car
+                    ) {
+                        return Collections;
+                    }
+                }""" );
 
     }
 
@@ -439,20 +442,21 @@ public class JavaExpressionInjectionTest extends MapstructBaseCompletionTestCase
         String mapper = formatMapper( CAR_MAPPER_MULTI_SOURCE, mapping );
         configureMapperByText( mapper );
 
-        assertJavaFragment( "import CarMapper;\n" +
-            "import org.example.dto.Car;\n" +
-            "\n" +
-            "@SuppressWarnings(\"unused\")\n" +
-            "abstract class CarMapperImpl\n" +
-            "    implements CarMapper {\n" +
-            "\n" +
-            "    String __test__(\n" +
-            "        Car car,\n" +
-            "        String make\n" +
-            "    ) {\n" +
-            "        return car.;\n" +
-            "    }\n" +
-            "}" );
+        assertJavaFragment( """
+                import CarMapper;
+                import org.example.dto.Car;
+
+                @SuppressWarnings("unused")
+                abstract class CarMapperImpl
+                    implements CarMapper {
+
+                    String __test__(
+                        Car car,
+                        String make
+                    ) {
+                        return car.;
+                    }
+                }""" );
     }
 
     public void testExpressionWithGenericSourceParameters() {
@@ -468,20 +472,21 @@ public class JavaExpressionInjectionTest extends MapstructBaseCompletionTestCase
         String mapper = formatMapper( CAR_MAPPER_FROM_WRAPPER, mapping );
         configureMapperByText( mapper );
 
-        assertJavaFragment( "import CarMapper;\n" +
-            "import org.example.dto.Car;\n" +
-            "import org.example.dto.Wrapper;\n" +
-            "\n" +
-            "@SuppressWarnings(\"unused\")\n" +
-            "abstract class CarMapperImpl\n" +
-            "    implements CarMapper {\n" +
-            "\n" +
-            "    String __test__(\n" +
-            "        Wrapper<Car> carWrapper\n" +
-            "    ) {\n" +
-            "        return carWrapper.getValue().;\n" +
-            "    }\n" +
-            "}" );
+        assertJavaFragment( """
+                import CarMapper;
+                import org.example.dto.Car;
+                import org.example.dto.Wrapper;
+
+                @SuppressWarnings("unused")
+                abstract class CarMapperImpl
+                    implements CarMapper {
+
+                    String __test__(
+                        Wrapper<Car> carWrapper
+                    ) {
+                        return carWrapper.getValue().;
+                    }
+                }""" );
     }
 
     public void testExpressionWithSourceParameterWithAnnotations() {
@@ -497,21 +502,22 @@ public class JavaExpressionInjectionTest extends MapstructBaseCompletionTestCase
         String mapper = formatMapper( CAR_MAPPER_FROM_WRAPPER_WITH_ANNOTATION, mapping );
         configureMapperByText( mapper );
 
-        assertJavaFragment( "import CarMapper;\n" +
-            "import org.example.dto.Car;\n" +
-            "import org.example.dto.Wrapper;\n" +
-            "\n" +
-            "@SuppressWarnings(\"unused\")\n" +
-            "abstract class CarMapperImpl\n" +
-            "    implements CarMapper {\n" +
-            "\n" +
-            "    String __test__(\n" +
-            "        @Context\n" +
-            "        Wrapper<Car> carWrapper\n" +
-            "    ) {\n" +
-            "        return carWrapper.getValue().;\n" +
-            "    }\n" +
-            "}" );
+        assertJavaFragment( """
+                import CarMapper;
+                import org.example.dto.Car;
+                import org.example.dto.Wrapper;
+
+                @SuppressWarnings("unused")
+                abstract class CarMapperImpl
+                    implements CarMapper {
+
+                    String __test__(
+                        @Context
+                        Wrapper<Car> carWrapper
+                    ) {
+                        return carWrapper.getValue().;
+                    }
+                }""" );
     }
 
     public void testExpressionWithSourceParameterWithMultipleGenerics() {
@@ -527,21 +533,22 @@ public class JavaExpressionInjectionTest extends MapstructBaseCompletionTestCase
         String mapper = formatMapper( CAR_MAPPER_FROM_WRAPPER_WITH_MULTI_GENERICS, mapping );
         configureMapperByText( mapper );
 
-        assertJavaFragment( "import CarMapper;\n" +
-            "import java.util.function.BiFunction;\n" +
-            "import org.example.dto.Car;\n" +
-            "import org.example.dto.Wrapper;\n" +
-            "\n" +
-            "@SuppressWarnings(\"unused\")\n" +
-            "abstract class CarMapperImpl\n" +
-            "    implements CarMapper {\n" +
-            "\n" +
-            "    String __test__(\n" +
-            "        Wrapper<BiFunction<String, Number, Car>> carWrapper\n" +
-            "    ) {\n" +
-            "        return carWrapper.getValue().apply(null, null).;\n" +
-            "    }\n" +
-            "}" );
+        assertJavaFragment( """
+                import CarMapper;
+                import java.util.function.BiFunction;
+                import org.example.dto.Car;
+                import org.example.dto.Wrapper;
+
+                @SuppressWarnings("unused")
+                abstract class CarMapperImpl
+                    implements CarMapper {
+
+                    String __test__(
+                        Wrapper<BiFunction<String, Number, Car>> carWrapper
+                    ) {
+                        return carWrapper.getValue().apply(null, null).;
+                    }
+                }""" );
     }
 
     public void testExpressionWithGenericMethod() {
@@ -556,19 +563,20 @@ public class JavaExpressionInjectionTest extends MapstructBaseCompletionTestCase
         String mapper = formatMapper( CAR_MAPPER_FROM_NUMBER_WRAPPER, mapping );
         configureMapperByText( mapper );
 
-        assertJavaFragment( "import CarMapper;\n" +
-            "import org.example.dto.NumberWrapper;\n" +
-            "\n" +
-            "@SuppressWarnings(\"unused\")\n" +
-            "abstract class CarMapperImpl\n" +
-            "    implements CarMapper {\n" +
-            "\n" +
-            "    <T extends Number> int __test__(\n" +
-            "        NumberWrapper<T> numberWrapper\n" +
-            "    ) {\n" +
-            "        return numberWrapper.;\n" +
-            "    }\n" +
-            "}" );
+        assertJavaFragment( """
+                import CarMapper;
+                import org.example.dto.NumberWrapper;
+
+                @SuppressWarnings("unused")
+                abstract class CarMapperImpl
+                    implements CarMapper {
+
+                    <T extends Number> int __test__(
+                        NumberWrapper<T> numberWrapper
+                    ) {
+                        return numberWrapper.;
+                    }
+                }""" );
     }
 
     public void testExpressionWithGenericMapper() {
@@ -583,20 +591,21 @@ public class JavaExpressionInjectionTest extends MapstructBaseCompletionTestCase
         String mapper = formatMapper( GENERIC_MAPPER, mapping );
         configureMapperByText( mapper );
 
-        assertJavaFragment( "import CarMapper;\n" +
-            "import org.example.dto.Car;\n" +
-            "\n" +
-            "@SuppressWarnings(\"unused\")\n" +
-            "abstract class CarMapperImpl<T, R>\n" +
-            "    implements CarMapper<T, R> {\n" +
-            "\n" +
-            "    String __test__(\n" +
-            "        Car car,\n" +
-            "        String make\n" +
-            "    ) {\n" +
-            "        return car.;\n" +
-            "    }\n" +
-            "}" );
+        assertJavaFragment( """
+                import CarMapper;
+                import org.example.dto.Car;
+
+                @SuppressWarnings("unused")
+                abstract class CarMapperImpl<T, R>
+                    implements CarMapper<T, R> {
+
+                    String __test__(
+                        Car car,
+                        String make
+                    ) {
+                        return car.;
+                    }
+                }""" );
     }
 
     public void testExpressionWithClassMapper() {
@@ -619,19 +628,20 @@ public class JavaExpressionInjectionTest extends MapstructBaseCompletionTestCase
             "    CarDto carToCarDto(Car car);\n" +
             "}" );
 
-        assertJavaFragment( "import CarMapper;\n" +
-            "import org.example.dto.Car;\n" +
-            "\n" +
-            "@SuppressWarnings(\"unused\")\n" +
-            "abstract class CarMapperImpl\n" +
-            "    extends CarMapper {\n" +
-            "\n" +
-            "    String __test__(\n" +
-            "        Car car\n" +
-            "    ) {\n" +
-            "        return car.;\n" +
-            "    }\n" +
-            "}" );
+        assertJavaFragment( """
+                import CarMapper;
+                import org.example.dto.Car;
+
+                @SuppressWarnings("unused")
+                abstract class CarMapperImpl
+                    extends CarMapper {
+
+                    String __test__(
+                        Car car
+                    ) {
+                        return car.;
+                    }
+                }""" );
     }
 
     public void testExpressionWithTargetUsingStaticString() {
@@ -655,19 +665,20 @@ public class JavaExpressionInjectionTest extends MapstructBaseCompletionTestCase
             "    CarDto carToCarDto(Car car);\n" +
             "}" );
 
-        assertJavaFragment( "import CarMapper;\n" +
-            "import org.example.dto.Car;\n" +
-            "\n" +
-            "@SuppressWarnings(\"unused\")\n" +
-            "abstract class CarMapperImpl\n" +
-            "    extends CarMapper {\n" +
-            "\n" +
-            "    String __test__(\n" +
-            "        Car car\n" +
-            "    ) {\n" +
-            "        return car.;\n" +
-            "    }\n" +
-            "}" );
+        assertJavaFragment( """
+                import CarMapper;
+                import org.example.dto.Car;
+
+                @SuppressWarnings("unused")
+                abstract class CarMapperImpl
+                    extends CarMapper {
+
+                    String __test__(
+                        Car car
+                    ) {
+                        return car.;
+                    }
+                }""" );
     }
 
     public void testExpressionWithMapperToDtoWithoutAccessors() {

--- a/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspectionCaretAfterQuickfixTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspectionCaretAfterQuickfixTest.java
@@ -6,7 +6,6 @@
 package org.mapstruct.intellij.inspection;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.intellij.codeInsight.intention.IntentionAction;
 import com.intellij.openapi.editor.Caret;
@@ -40,7 +39,7 @@ public class UnmappedTargetPropertiesInspectionCaretAfterQuickfixTest extends Ba
         List<IntentionAction> addMissingTargetQuickfixes = myFixture.getAllQuickFixes()
             .stream()
             .filter( i -> i.getText().startsWith( "Add unmapped target property " ) )
-            .collect( Collectors.toList() );
+            .toList();
 
         addMissingTargetQuickfixes.forEach( this::launchAndAssertCaretPositionInSource );
     }
@@ -51,7 +50,7 @@ public class UnmappedTargetPropertiesInspectionCaretAfterQuickfixTest extends Ba
         List<IntentionAction> addMissingTargetQuickfixes = myFixture.getAllQuickFixes()
             .stream()
             .filter( i -> i.getText().startsWith( "Ignore unmapped target property" ) )
-            .collect( Collectors.toList() );
+            .toList();
 
         addMissingTargetQuickfixes.forEach( this::launchAndAssertUnchangedCaretPosition );
     }
@@ -62,7 +61,7 @@ public class UnmappedTargetPropertiesInspectionCaretAfterQuickfixTest extends Ba
         List<IntentionAction> addMissingTargetQuickfixes = myFixture.getAllQuickFixes()
             .stream()
             .filter( i -> i.getText().startsWith( "Ignore all unmapped target properties" ) )
-            .collect( Collectors.toList() );
+            .toList();
 
         addMissingTargetQuickfixes.forEach( this::launchAndAssertUnchangedCaretPosition );
     }


### PR DESCRIPTION
I removed support for idea 2022.1. This was the last version using Java 11. In addition I also used remove the new migration aids. Where possible I used enhanced switches, text blocks and the new instanceof casts.