### PR TITLE
#211 Remove methods should not be considered fluent setters.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ dependencies {
         testFramework( TestFrameworkType.Platform.INSTANCE )
         testFramework( TestFrameworkType.Bundled.INSTANCE )
     }
-    implementation('org.mapstruct:mapstruct:1.5.3.Final')
+    implementation('org.mapstruct:mapstruct:1.7.0-SNAPSHOT')
     testImplementation(platform('org.junit:junit-bom:5.11.0'))
     testImplementation('org.junit.platform:junit-platform-launcher')
     testImplementation('org.junit.jupiter:junit-jupiter-api')
@@ -130,7 +130,7 @@ tasks.register('libs', Sync) {
         include('mapstruct-intellij-*.jar')
         include('MapStruct-Intellij-*.jar')
     }
-    rename('mapstruct-1.5.3.Final.jar', 'mapstruct.jar')
+    rename('mapstruct-1.7.0-SNAPSHOT.jar', 'mapstruct.jar')
 }
 
 tasks.register('testLibs', Sync) {

--- a/src/main/java/org/mapstruct/intellij/util/MapStructVersion.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapStructVersion.java
@@ -10,16 +10,19 @@ package org.mapstruct.intellij.util;
  */
 public enum MapStructVersion {
 
-    V1_2_O( false, false ),
-    V1_3_O( true, false ),
-    V1_4_O( true, true );
+    V1_2_O( false, false, false ),
+    V1_3_O( true, false, false ),
+    V1_4_O( true, true, false ),
+    V1_7_O( true, true, true ),;
 
     private final boolean builderSupported;
     private final boolean constructorSupported;
+    private final boolean ignoringRemovers;
 
-    MapStructVersion(boolean builderSupported, boolean constructorSupported) {
+    MapStructVersion(boolean builderSupported, boolean constructorSupported, boolean ignoringRemovers) {
         this.builderSupported = builderSupported;
         this.constructorSupported = constructorSupported;
+        this.ignoringRemovers = ignoringRemovers;
     }
 
     public boolean isBuilderSupported() {
@@ -28,5 +31,9 @@ public enum MapStructVersion {
 
     public boolean isConstructorSupported() {
         return constructorSupported;
+    }
+
+    public boolean isIgnoringRemovers() {
+        return ignoringRemovers;
     }
 }

--- a/testData/mapping/dto/CarDto.java
+++ b/testData/mapping/dto/CarDto.java
@@ -83,6 +83,12 @@ public class CarDto {
         this.passengers.add( passenger );
     }
 
+    public void removePassenger(PersonDTO passenger) {
+        if ( this.passengers != null ) {
+            this.passengers.remove( passenger );
+        }
+    }
+
     public Long getPrice() {
         return price;
     }

--- a/testData/mapping/dto/FluentCarDto.java
+++ b/testData/mapping/dto/FluentCarDto.java
@@ -75,6 +75,13 @@ public class FluentCarDto {
         return this;
     }
 
+    public FluentCarDto removePassenger(PersonDto passenger) {
+        if ( this.passengers != null ) {
+            this.passengers.remove( passenger );
+        }
+        return this;
+    }
+
     public Long getPrice() {
         return price;
     }


### PR DESCRIPTION
This is a first take on it.

With this change fluent remover's will be ignored when verifying the mapper. A remover (removePassenger) is added to FluentCarDTO as part of the tests.

Tested it with IntelliJ as well and seems to be working as intended, but I would be more than happy for feedback and suggestions.