### PR TITLE
#236: Do not register problems on mapping composition annotations

### DIFF
--- a/src/main/java/org/mapstruct/intellij/inspection/MapstructReferenceInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/MapstructReferenceInspection.java
@@ -5,8 +5,6 @@
  */
 package org.mapstruct.intellij.inspection;
 
-import java.util.Optional;
-
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.openapi.util.TextRange;
@@ -73,9 +71,14 @@ public class MapstructReferenceInspection extends InspectionBase {
         }
 
         private boolean containingClassIsAnnotationType(PsiElement element) {
-            return Optional.ofNullable( PsiTreeUtil.getParentOfType( element, PsiClass.class ) )
-                .map( PsiClass::isAnnotationType )
-                .orElse( false );
+
+            PsiClass containingClass = PsiTreeUtil.getParentOfType( element, PsiClass.class );
+
+            if ( containingClass == null ) {
+                return false;
+            }
+
+            return containingClass.isAnnotationType();
         }
     }
 }

--- a/src/main/java/org/mapstruct/intellij/inspection/MapstructReferenceInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/MapstructReferenceInspection.java
@@ -5,14 +5,18 @@
  */
 package org.mapstruct.intellij.inspection;
 
+import java.util.Optional;
+
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.ContributedReferenceHost;
+import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiLanguageInjectionHost;
 import com.intellij.psi.PsiReference;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 import org.mapstruct.intellij.codeinsight.references.BaseReference;
 import org.mapstruct.intellij.codeinsight.references.BaseValueMappingReference;
@@ -64,7 +68,14 @@ public class MapstructReferenceInspection extends InspectionBase {
             if ( reference instanceof BaseValueMappingReference valueMappingReference ) {
                 return valueMappingReference.getEnumClass() != null;
             }
-            return true;
+
+            return !containingClassIsAnnotationType( reference.getElement() );
+        }
+
+        private boolean containingClassIsAnnotationType(PsiElement element) {
+            return Optional.ofNullable( PsiTreeUtil.getParentOfType( element, PsiClass.class ) )
+                .map( PsiClass::isAnnotationType )
+                .orElse( false );
         }
     }
 }

--- a/src/test/java/org/mapstruct/intellij/bugs/_236/DisableSourceAndTargetPropertyInspectionOnAnnotationsTest.java
+++ b/src/test/java/org/mapstruct/intellij/bugs/_236/DisableSourceAndTargetPropertyInspectionOnAnnotationsTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.intellij.bugs._236;
+
+import org.jetbrains.annotations.NotNull;
+import org.mapstruct.intellij.inspection.BaseInspectionTest;
+import org.mapstruct.intellij.inspection.MapstructReferenceInspection;
+
+/**
+ * @author Oliver Erhart
+ */
+public class DisableSourceAndTargetPropertyInspectionOnAnnotationsTest extends BaseInspectionTest {
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/bugs/_236";
+    }
+
+    @NotNull
+    @Override
+    protected Class<MapstructReferenceInspection> getInspection() {
+        return MapstructReferenceInspection.class;
+    }
+
+    public void testDisableSourceAndTargetPropertyInspectionOnAnnotations() {
+        doTest();
+    }
+}

--- a/testData/bugs/_236/DisableSourceAndTargetPropertyInspectionOnAnnotations.java
+++ b/testData/bugs/_236/DisableSourceAndTargetPropertyInspectionOnAnnotations.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.mapstruct.Mapping;
+
+@Retention(RetentionPolicy.CLASS)
+@Mapping(target = "id", ignore = true)
+@Mapping(target = "creationDate", expression = "java(new java.util.Date())")
+@Mapping(target = "name", source = "groupName")
+@interface ToEntity { }

--- a/testData/bugs/_236/DisableSourceAndTargetPropertyInspectionOnAnnotations.java
+++ b/testData/bugs/_236/DisableSourceAndTargetPropertyInspectionOnAnnotations.java
@@ -8,9 +8,19 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
 
 @Retention(RetentionPolicy.CLASS)
 @Mapping(target = "id", ignore = true)
 @Mapping(target = "creationDate", expression = "java(new java.util.Date())")
 @Mapping(target = "name", source = "groupName")
 @interface ToEntity { }
+
+@Retention(RetentionPolicy.CLASS)
+@Mappings({
+    @Mapping(target = "id", ignore = true),
+    @Mapping(target = "creationDate", expression = "java(new java.util.Date())"),
+    @Mapping(target = "name", source = "groupName")
+})
+@interface ToEntityWithMappings { }
+


### PR DESCRIPTION
closes #236 

I tried to disable it by excluding it in the `MapstructReferenceContributor` when using the [`elementPattern`](https://github.com/mapstruct/mapstruct-idea/blob/59026197610f7d27f12cdc122961d35e753206ae/src/main/java/org/mapstruct/intellij/util/MapstructElementUtils.java#L78)` but somehow this did not get called.

Therefore I used the check inside `shouldRegisterProblem(...)` to exclude it.