### PR TITLE
Add @Ignored annotation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ To learn more about MapStruct have a look at the [mapstruct](https://github.com/
 * Code completions
   * Completion of `target` and `source` properties in `@Mapping` annotation (nested properties also work)
   * Completion of `target` and `source` properties in `@ValueMapping` annotation
+  * Completion of `targets` in `@Ignored` annotation with `prefix` support
   * Completion of `componentModel` in `@Mapper` and `@MapperConfig` annotations
   * Completion of `qualifiedByName` in `@Mapping` annotation
 * Go To Declaration for properties in `target` and `source` to setters / getters
+* Go To Declaration for `targets` in `@Ignored` annotation
 * Go To Declaration for `Mapping#qualifiedByName`
-* Find usages of properties in `target` and `source` and find usages of setters / getters in `@Mapping` annotations
+* Find usages of properties in `target` and `source` and find usages of setters / getters in `@Mapping` and `@Ignored` annotations
 * Highlighting properties in `target` and `source`
 * Errors and Quick fixes:
   * `@Mapper` or `@MapperConfig` annotation missing
@@ -37,9 +39,10 @@ To learn more about MapStruct have a look at the [mapstruct](https://github.com/
   * No `source` defined in `@Mapping` annotation
   * More than one `source` in `@Mapping` annotation defined with quick fixes: Remove `source`. Remove `constant`. Remove `expression`. Use `constant` as `defaultValue`. Use `expression` as `defaultExpression`. 
   * More than one default source in `@Mapping` annotation defined with quick fixes: Remove `defaultValue`. Remove `defaultExpression`.
-  * `target` mapped more than once by `@Mapping` annotations with quick fixes: Remove annotation and change target property.
+  * `target` mapped more than once by `@Mapping` and/or `@Ignored` annotations with quick fixes: Remove annotation and change target property.
   * `*` used as a source in `@Mapping` annotation with quick fixes: Replace `*` with method parameter name.
-  * Unknown reference inspection for `source` and `target` in `@Mapping` and `@ValueMapping` annotation. 
+  * Unknown reference inspection for `source` and `target` in `@Mapping` and `@ValueMapping` annotation.
+  * Unknown reference inspection for `targets` and `prefix` in `@Ignored` annotation.
   * Unknown reference inspection for `qualifiedByName` in `@Mapping` annotation
  
 ## Requirements

--- a/build.gradle
+++ b/build.gradle
@@ -111,13 +111,13 @@ dependencies {
         testFramework( TestFrameworkType.Platform.INSTANCE )
         testFramework( TestFrameworkType.Bundled.INSTANCE )
     }
-    implementation('org.mapstruct:mapstruct:1.5.3.Final')
+    implementation('org.mapstruct:mapstruct:1.7.0.Beta1')
     testImplementation(platform('org.junit:junit-bom:5.11.0'))
     testImplementation('org.junit.platform:junit-platform-launcher')
     testImplementation('org.junit.jupiter:junit-jupiter-api')
     testImplementation('org.junit.jupiter:junit-jupiter-engine')
     testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
-    testImplementation('org.assertj:assertj-core:3.26.3')
+    testImplementation('org.assertj:assertj-core:3.27.7')
     testImplementation('org.apache.commons:commons-text:1.15.0')
     testImplementation( 'junit:junit:4.13.2' )
     testRuntimeOnly('org.immutables:value:2.10.1')
@@ -130,7 +130,9 @@ tasks.register('libs', Sync) {
         include('mapstruct-intellij-*.jar')
         include('MapStruct-Intellij-*.jar')
     }
-    rename('mapstruct-1.5.3.Final.jar', 'mapstruct.jar')
+    rename { String fileName ->
+        return fileName.startsWith('mapstruct-') ? 'mapstruct.jar' : fileName
+    }
 }
 
 tasks.register('testLibs', Sync) {

--- a/change-notes.html
+++ b/change-notes.html
@@ -1,4 +1,16 @@
 <html lang="en">
+<h2>1.10.0</h2>
+<ul>
+    <li>Support for <code>@Ignored</code> annotation (MapStruct 1.7):
+        <ul>
+            <li>Code completion for <code>targets</code> in <code>@Ignored</code> annotation with <code>prefix</code> support</li>
+            <li>Go to declaration and find usages for <code>@Ignored</code> target properties</li>
+            <li>Unknown reference inspection for <code>targets</code> and <code>prefix</code> in <code>@Ignored</code> annotation</li>
+            <li>Unmapped target properties inspection considers <code>@Ignored</code> targets</li>
+            <li>Target mapped more than once inspection detects conflicts between <code>@Mapping</code> and <code>@Ignored</code></li>
+        </ul>
+    </li>
+</ul>
 <h2>1.9.1</h2>
 <ul>
     <li>Improve error messages for reference inspection</li>

--- a/description.html
+++ b/description.html
@@ -23,12 +23,14 @@ If you want to discuss specific topics, then ping me (@filiphr) in the MapStruct
     <ul>
         <li>Completion of <code>target</code> and <code>source</code> properties in <code>@Mapping</code> annotation (nested properties also work)</li>
         <li>Completion of <code>target</code> and <code>source</code> properties in <code>@ValueMapping</code> annotation</li>
+        <li>Completion of <code>targets</code> in <code>@Ignored</code> annotation with <code>prefix</code> support</li>
         <li>Completion of <code>componentModel</code> in <code>@Mapper</code> and <code>@MapperConfig</code> annotations</li>
         <li>Completion of <code>qualifiedByName</code> in <code>@Mapping</code> annotation</li>
     </ul>
     </li>
     <li>Go To Declaration for properties in <code>target</code> and <code>source</code> to setters / getters</li>
-    <li>Find usages of properties in <code>target</code> and <code>source</code> and find usages of setters / getters in <code>@Mapping</code> annotations</li>
+    <li>Go To Declaration for <code>targets</code> in <code>@Ignored</code> annotation</li>
+    <li>Find usages of properties in <code>target</code> and <code>source</code> and find usages of setters / getters in <code>@Mapping</code> and <code>@Ignored</code> annotations</li>
     <li>Go To Declaration for <code>Mapping#qualifiedByName</code></li>
     <li>Highlighting properties in <code>target</code> and <code>source</code></li>
     <li>Refactoring support for properties and methods renaming</li>
@@ -41,9 +43,10 @@ If you want to discuss specific topics, then ping me (@filiphr) in the MapStruct
         <li>No <code>source</code> defined in <code>@Mapping</code> annotation</li>
         <li>More than one <code>source</code> in <code>@Mapping</code> annotation defined with quick fixes: Remove <code>source</code>. Remove <code>constant</code>. Remove <code>expression</code>. Use <code>constant</code> as <code>defaultValue</code>. Use <code>expression</code> as <code>defaultExpression</code>.</li>
         <li>More than one default source in <code>@Mapping</code> annotation defined with quick fixes: Remove <code>defaultValue</code>. Remove <code>defaultExpression</code>.</li>
-        <li><code>target</code> mapped more than once by <code>@Mapping</code> annotations with quick fixes: Remove annotation and change target property.</li>
+        <li><code>target</code> mapped more than once by <code>@Mapping</code> and/or <code>@Ignored</code> annotations with quick fixes: Remove annotation and change target property.</li>
         <li><code>*</code> used as a source in <code>@Mapping</code> annotations with quick fixes: Replace <code>*</code> with method parameter name.</li>
-        <li>Unknown reference inspection for <code>source</code> and <code>target</code> in <code>@Mapping</code> and <code>@ValueMapping</code> annotation. </li>
+        <li>Unknown reference inspection for <code>source</code> and <code>target</code> in <code>@Mapping</code> and <code>@ValueMapping</code> annotation.</li>
+        <li>Unknown reference inspection for <code>targets</code> and <code>prefix</code> in <code>@Ignored</code> annotation.</li>
         <li>Unknown reference inspection for <code>qualifiedByName</code> in <code>@Mapping</code> annotation. </li>
     </ul>
     </li>

--- a/src/main/java/org/mapstruct/intellij/codeinsight/references/BaseTargetReference.java
+++ b/src/main/java/org/mapstruct/intellij/codeinsight/references/BaseTargetReference.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.intellij.codeinsight.references;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiParameter;
+import com.intellij.psi.PsiParameterList;
+import com.intellij.psi.PsiRecordComponent;
+import com.intellij.psi.PsiSubstitutor;
+import com.intellij.psi.PsiType;
+import com.intellij.psi.PsiVariable;
+import com.intellij.psi.util.PsiUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mapstruct.intellij.util.MapStructVersion;
+import org.mapstruct.intellij.util.MapstructUtil;
+import org.mapstruct.intellij.util.TargetType;
+import org.mapstruct.intellij.util.TargetUtils;
+
+import static org.mapstruct.intellij.util.MapstructUtil.asLookup;
+import static org.mapstruct.intellij.util.MapstructUtil.findRecordComponent;
+import static org.mapstruct.intellij.util.MapstructUtil.isPublicModifiable;
+import static org.mapstruct.intellij.util.MapstructUtil.isPublicNonStatic;
+import static org.mapstruct.intellij.util.TargetUtils.findAllDefinedMappingTargets;
+import static org.mapstruct.intellij.util.TargetUtils.findAllIgnoredTargets;
+import static org.mapstruct.intellij.util.TargetUtils.isBuilderEnabled;
+import static org.mapstruct.intellij.util.TargetUtils.publicWriteAccessors;
+import static org.mapstruct.intellij.util.TargetUtils.resolveBuilderOrSelfClass;
+import static org.mapstruct.intellij.util.TypeUtils.firstParameterPsiType;
+
+/**
+ * Base class for target references ({@link MapstructTargetReference} and {@link MapstructIgnoredTargetReference}).
+ * Provides shared implementations for resolving the type of target elements.
+ *
+ * @author Filip Hrisafov
+ */
+abstract class BaseTargetReference extends BaseMappingReference {
+
+    protected final MapStructVersion mapStructVersion;
+
+    BaseTargetReference(@NotNull PsiElement element, @Nullable MapstructBaseReference previousReference,
+                        TextRange rangeInElement, String value) {
+        super( element, previousReference, rangeInElement, value );
+        mapStructVersion = MapstructUtil.resolveMapStructProjectVersion( element.getContainingFile()
+            .getOriginalFile() );
+    }
+
+    @Override
+    PsiElement resolveInternal(@NotNull String value, @NotNull PsiType psiType) {
+        return resolveTargetElement( value, psiType, getMappingMethod() );
+    }
+
+    PsiElement resolveTargetElement(@NotNull String value, @NotNull PsiType psiType,
+                                    @Nullable PsiMethod mappingMethod) {
+        boolean builderSupportPresent = mapStructVersion.isBuilderSupported();
+        Pair<PsiClass, TargetType> pair = resolveBuilderOrSelfClass(
+            psiType,
+            builderSupportPresent && isBuilderEnabled( mappingMethod )
+        );
+        if ( pair == null ) {
+            return null;
+        }
+
+        PsiClass psiClass = pair.getFirst();
+        TargetType targetType = pair.getSecond();
+        PsiType typeToUse = targetType.type();
+
+        PsiRecordComponent recordComponent = findRecordComponent( value, psiClass );
+        if ( recordComponent != null ) {
+            return recordComponent;
+        }
+
+        if ( mapStructVersion.isConstructorSupported() && !targetType.builder() ) {
+            PsiMethod constructor = TargetUtils.resolveMappingConstructor( psiClass );
+            if ( constructor != null && constructor.hasParameters() ) {
+                for ( PsiParameter parameter : constructor.getParameterList().getParameters() ) {
+                    if ( value.equals( parameter.getName() ) ) {
+                        return parameter;
+                    }
+                }
+            }
+        }
+
+        String capitalizedName = MapstructUtil.capitalize( value );
+        PsiMethod[] methods = psiClass.findMethodsByName( "set" + capitalizedName, true );
+        if ( methods.length != 0 && isPublicNonStatic( methods[0] ) ) {
+            return methods[0];
+        }
+
+        // If there is no such setter we need to check if there is a collection getter
+        methods = psiClass.findMethodsByName( "get" + capitalizedName, true );
+        if ( methods.length != 0 && isCollectionGetterWriteAccessor( methods[0] ) ) {
+            return methods[0];
+        }
+
+        if ( builderSupportPresent ) {
+            for ( Pair<PsiMethod, PsiSubstitutor> builderPair : psiClass.findMethodsAndTheirSubstitutorsByName(
+                value,
+                true
+            ) ) {
+                PsiMethod method = builderPair.getFirst();
+                if ( method.getParameterList().getParametersCount() == 1 &&
+                    mapstructUtil.isFluentSetter( method, typeToUse, builderPair.getSecond() ) ) {
+                    return method;
+                }
+            }
+        }
+
+        PsiClass selfClass = PsiUtil.resolveClassInType( psiType );
+        if ( selfClass != null ) {
+            PsiField field = selfClass.findFieldByName( value, true );
+            if ( field != null && isPublicModifiable( field ) ) {
+                return field;
+            }
+        }
+
+        return null;
+    }
+
+    @NotNull
+    @Override
+    Object[] getVariantsInternal(@NotNull PsiType psiType) {
+
+        PsiMethod mappingMethod = getMappingMethod();
+
+        Map<String, Pair<? extends PsiElement, PsiSubstitutor>> accessors = publicWriteAccessors(
+            psiType,
+            mapStructVersion,
+            mapstructUtil,
+            mappingMethod
+        );
+
+        if ( mappingMethod != null ) {
+            findAllDefinedTargets( mappingMethod ).forEach( accessors::remove );
+        }
+
+        return asLookup(
+            accessors,
+            BaseTargetReference::memberPsiType
+        );
+    }
+
+    protected Stream<String> findAllDefinedTargets(PsiMethod mappingMethod) {
+        return Stream.concat(
+            findAllDefinedMappingTargets( mappingMethod, mapStructVersion ),
+            findAllIgnoredTargets( mappingMethod )
+        );
+    }
+
+    @Nullable
+    @Override
+    PsiType resolvedType() {
+        PsiElement element = resolve();
+        if ( element instanceof PsiMethod psiMethod ) {
+            return firstParameterPsiType( psiMethod );
+        }
+        else if ( element instanceof PsiParameter psiParameter ) {
+            return psiParameter.getType();
+        }
+        else if ( element instanceof PsiRecordComponent psiRecordComponent ) {
+            return psiRecordComponent.getType();
+        }
+        else if ( element instanceof PsiField psiField ) {
+            return psiField.getType();
+        }
+
+        return null;
+    }
+
+    static PsiType memberPsiType(PsiElement psiMember) {
+        if ( psiMember instanceof PsiMethod psiMemberMethod ) {
+            return resolveMethodType( psiMemberMethod );
+        }
+        else if ( psiMember instanceof PsiVariable psiMemberVariable ) {
+            return psiMemberVariable.getType();
+        }
+        return null;
+    }
+
+    static PsiType resolveMethodType(PsiMethod psiMethod) {
+        PsiParameter[] psiParameters = psiMethod.getParameterList().getParameters();
+        if ( psiParameters.length == 0 ) {
+            return psiMethod.getReturnType();
+        }
+        return psiParameters[0].getType();
+    }
+
+    private static boolean isCollectionGetterWriteAccessor(@NotNull PsiMethod method) {
+        if ( !isPublicNonStatic( method ) ) {
+            return false;
+        }
+        PsiParameterList parameterList = method.getParameterList();
+        if ( parameterList.getParametersCount() > 0 ) {
+            return false;
+        }
+        return TargetUtils.isMethodReturnTypeAssignableToCollectionOrMap( method );
+    }
+}

--- a/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructIgnoredTargetReference.java
+++ b/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructIgnoredTargetReference.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.intellij.codeinsight.references;
+
+import java.util.stream.Stream;
+
+import com.intellij.codeInsight.AnnotationUtil;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.PsiType;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mapstruct.intellij.util.TargetUtils;
+
+import static org.mapstruct.intellij.util.MapstructUtil.canDescendIntoType;
+import static org.mapstruct.intellij.util.TargetUtils.getRelevantType;
+
+/**
+ * Reference for {@link org.mapstruct.Ignored#targets()}.
+ *
+ * @author Filip Hrisafov
+ */
+class MapstructIgnoredTargetReference extends BaseTargetReference {
+
+    private MapstructIgnoredTargetReference(PsiElement element, MapstructIgnoredTargetReference previousReference,
+        TextRange rangeInElement, String value) {
+        super( element, previousReference, rangeInElement, value );
+    }
+
+    @Nullable
+    @Override
+    PsiElement resolveInternal(@NotNull String value, @NotNull PsiMethod mappingMethod) {
+        PsiType targetType = resolveIgnoredTargetsBaseType( mappingMethod );
+        return targetType == null ? null : resolveInternal( value, targetType );
+    }
+
+    @Override
+    protected Stream<String> findAllDefinedTargets(PsiMethod mappingMethod) {
+        PsiAnnotation annotation = PsiTreeUtil.getParentOfType( getElement(), PsiAnnotation.class );
+
+        Stream<String> allTargets = super.findAllDefinedTargets( mappingMethod );
+
+        String prefixDot = TargetUtils.getIgnoredPrefix( annotation );
+
+        if ( !prefixDot.isEmpty() ) {
+            allTargets = allTargets
+                .filter( target -> target.startsWith( prefixDot ) )
+                .map( target -> target.substring( prefixDot.length() ) );
+        }
+        return allTargets;
+    }
+
+    @NotNull
+    @Override
+    Object[] getVariantsInternal(@NotNull PsiMethod mappingMethod) {
+        PsiType targetType = resolveIgnoredTargetsBaseType( mappingMethod );
+        return targetType == null ? LookupElement.EMPTY_ARRAY : getVariantsInternal( targetType );
+    }
+
+    static PsiReference[] create(PsiElement psiElement) {
+        return MapstructBaseReference.create( psiElement, MapstructIgnoredTargetReference::new, true );
+    }
+
+    @Nullable
+    private PsiType resolveIgnoredTargetsBaseType(@NotNull PsiMethod mappingMethod) {
+        PsiType targetType = getRelevantType( mappingMethod );
+        if ( targetType == null ) {
+            return null;
+        }
+
+        PsiAnnotation annotation = PsiTreeUtil.getParentOfType( getElement(), PsiAnnotation.class );
+        if ( annotation == null ) {
+            return targetType;
+        }
+
+        String prefix = AnnotationUtil.getDeclaredStringAttributeValue( annotation, "prefix" );
+        if ( prefix == null || prefix.isEmpty() ) {
+            return targetType;
+        }
+
+        PsiElement prefixElement = annotation.findDeclaredAttributeValue( "prefix" );
+        if ( prefixElement == null ) {
+            return targetType;
+        }
+
+        PsiReference[] prefixReferences = MapstructTargetReference.create( prefixElement );
+        if ( prefixReferences.length == 0 ) {
+            return null;
+        }
+
+        PsiReference lastReference = prefixReferences[prefixReferences.length - 1];
+        if ( lastReference instanceof MapstructBaseReference baseReference ) {
+            PsiType resolvedType = baseReference.resolvedType();
+            return canDescendIntoType( resolvedType ) ? resolvedType : null;
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructKotlinReferenceContributor.java
+++ b/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructKotlinReferenceContributor.java
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiReferenceRegistrar;
 import org.jetbrains.annotations.NotNull;
 
 import static org.mapstruct.intellij.util.MapstructKotlinElementUtils.beanMappingElementPattern;
+import static org.mapstruct.intellij.util.MapstructKotlinElementUtils.ignoredElementPattern;
 import static org.mapstruct.intellij.util.MapstructKotlinElementUtils.mappingElementPattern;
 import static org.mapstruct.intellij.util.MapstructKotlinElementUtils.valueMappingElementPattern;
 
@@ -30,6 +31,14 @@ public class MapstructKotlinReferenceContributor extends PsiReferenceContributor
         registrar.registerReferenceProvider(
             mappingElementPattern( "source" ),
             new MappingTargetReferenceProvider( MapstructSourceReference::create )
+        );
+        registrar.registerReferenceProvider(
+            ignoredElementPattern( "prefix" ),
+            new MappingTargetReferenceProvider( MapstructTargetReference::create )
+        );
+        registrar.registerReferenceProvider(
+            ignoredElementPattern( "targets" ),
+            new MappingTargetReferenceProvider( MapstructIgnoredTargetReference::create )
         );
         registrar.registerReferenceProvider(
             beanMappingElementPattern( "ignoreUnmappedSourceProperties" ),

--- a/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructReferenceContributor.java
+++ b/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructReferenceContributor.java
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiReferenceRegistrar;
 import org.jetbrains.annotations.NotNull;
 
 import static org.mapstruct.intellij.util.MapstructElementUtils.beanMappingElementPattern;
+import static org.mapstruct.intellij.util.MapstructElementUtils.ignoredElementPattern;
 import static org.mapstruct.intellij.util.MapstructElementUtils.mappingElementPattern;
 import static org.mapstruct.intellij.util.MapstructElementUtils.valueMappingElementPattern;
 
@@ -33,6 +34,14 @@ public class MapstructReferenceContributor extends PsiReferenceContributor {
         registrar.registerReferenceProvider(
             mappingElementPattern( "source" ),
             new MappingTargetReferenceProvider( MapstructSourceReference::create )
+        );
+        registrar.registerReferenceProvider(
+            ignoredElementPattern( "prefix" ),
+            new MappingTargetReferenceProvider( MapstructTargetReference::create )
+        );
+        registrar.registerReferenceProvider(
+            ignoredElementPattern( "targets" ),
+            new MappingTargetReferenceProvider( MapstructIgnoredTargetReference::create )
         );
 
         registrar.registerReferenceProvider(

--- a/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructTargetReference.java
+++ b/src/main/java/org/mapstruct/intellij/codeinsight/references/MapstructTargetReference.java
@@ -5,53 +5,26 @@
  */
 package org.mapstruct.intellij.codeinsight.references;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import com.intellij.codeInsight.AnnotationUtil;
 import com.intellij.codeInsight.lookup.LookupElement;
-import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.TextRange;
-import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiMethod;
-import com.intellij.psi.PsiParameter;
-import com.intellij.psi.PsiParameterList;
-import com.intellij.psi.PsiRecordComponent;
 import com.intellij.psi.PsiReference;
-import com.intellij.psi.PsiSubstitutor;
 import com.intellij.psi.PsiType;
-import com.intellij.psi.PsiVariable;
-import com.intellij.psi.util.PsiUtil;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.mapstruct.Mapping;
-import org.mapstruct.intellij.util.MapStructVersion;
 import org.mapstruct.intellij.util.MapstructUtil;
-import org.mapstruct.intellij.util.TargetType;
-import org.mapstruct.intellij.util.TargetUtils;
 
-import static org.mapstruct.intellij.util.MapstructAnnotationUtils.findAllDefinedMappingAnnotations;
-import static org.mapstruct.intellij.util.MapstructUtil.asLookup;
-import static org.mapstruct.intellij.util.MapstructUtil.findRecordComponent;
-import static org.mapstruct.intellij.util.MapstructUtil.isPublicModifiable;
-import static org.mapstruct.intellij.util.MapstructUtil.isPublicNonStatic;
 import static org.mapstruct.intellij.util.TargetUtils.getRelevantType;
-import static org.mapstruct.intellij.util.TargetUtils.isBuilderEnabled;
-import static org.mapstruct.intellij.util.TargetUtils.publicWriteAccessors;
-import static org.mapstruct.intellij.util.TargetUtils.resolveBuilderOrSelfClass;
-import static org.mapstruct.intellij.util.TypeUtils.firstParameterPsiType;
 
 /**
  * Reference for {@link org.mapstruct.Mapping#target()}.
  *
  * @author Filip Hrisafov
  */
-class MapstructTargetReference extends BaseMappingReference {
-
-    private final MapStructVersion mapStructVersion;
+class MapstructTargetReference extends BaseTargetReference {
 
     /**
      * Create a new {@link MapstructTargetReference} with the provided parameters
@@ -64,75 +37,6 @@ class MapstructTargetReference extends BaseMappingReference {
     private MapstructTargetReference(PsiElement element, MapstructTargetReference previousReference,
         TextRange rangeInElement, String value) {
         super( element, previousReference, rangeInElement, value );
-        mapStructVersion = MapstructUtil.resolveMapStructProjectVersion( element.getContainingFile()
-            .getOriginalFile() );
-    }
-
-    @Override
-    PsiElement resolveInternal(@NotNull String value, @NotNull PsiType psiType) {
-        boolean builderSupportPresent = mapStructVersion.isBuilderSupported();
-        Pair<PsiClass, TargetType> pair = resolveBuilderOrSelfClass(
-            psiType,
-            builderSupportPresent && isBuilderEnabled( getMappingMethod() )
-        );
-        if ( pair == null ) {
-            return null;
-        }
-
-        PsiClass psiClass = pair.getFirst();
-        TargetType targetType = pair.getSecond();
-        PsiType typeToUse = targetType.type();
-
-        PsiRecordComponent recordComponent = findRecordComponent( value, psiClass );
-        if ( recordComponent != null ) {
-            return recordComponent;
-        }
-
-        if ( mapStructVersion.isConstructorSupported() && !targetType.builder() ) {
-            PsiMethod constructor = TargetUtils.resolveMappingConstructor( psiClass );
-            if ( constructor != null && constructor.hasParameters() ) {
-                for ( PsiParameter parameter : constructor.getParameterList().getParameters() ) {
-                    if ( value.equals( parameter.getName() ) ) {
-                        return parameter;
-                    }
-                }
-            }
-        }
-
-        String capitalizedName = MapstructUtil.capitalize( value );
-        PsiMethod[] methods = psiClass.findMethodsByName( "set" + capitalizedName, true );
-        if ( methods.length != 0 && isPublicNonStatic( methods[0] ) ) {
-            return methods[0];
-        }
-
-        // If there is no such setter we need to check if there is a collection getter
-        methods = psiClass.findMethodsByName( "get" + capitalizedName, true );
-        if ( methods.length != 0 && isCollectionGetterWriteAccessor( methods[0] ) ) {
-            return methods[0];
-        }
-
-        if ( builderSupportPresent ) {
-            for ( Pair<PsiMethod, PsiSubstitutor> builderPair : psiClass.findMethodsAndTheirSubstitutorsByName(
-                value,
-                true
-            ) ) {
-                PsiMethod method = builderPair.getFirst();
-                if ( method.getParameterList().getParametersCount() == 1 &&
-                    mapstructUtil.isFluentSetter( method, typeToUse, builderPair.getSecond() ) ) {
-                    return method;
-                }
-            }
-        }
-
-        PsiClass selfClass = PsiUtil.resolveClassInType( psiType );
-        if ( selfClass != null ) {
-            PsiField field = selfClass.findFieldByName( value, true );
-            if ( field != null && isPublicModifiable( field ) ) {
-                return field;
-            }
-        }
-
-        return null;
     }
 
     @Override
@@ -142,7 +46,11 @@ class MapstructTargetReference extends BaseMappingReference {
             return null;
         }
 
-        PsiElement psiElement = resolveInternal( value, relevantType );
+        PsiElement psiElement = resolveTargetElement(
+            value,
+            relevantType,
+            mappingMethod
+        );
         if ( psiElement != null ) {
             return psiElement;
         }
@@ -156,68 +64,9 @@ class MapstructTargetReference extends BaseMappingReference {
 
     @NotNull
     @Override
-    Object[] getVariantsInternal(@NotNull PsiType psiType) {
-
-        PsiMethod mappingMethod = getMappingMethod();
-
-        Map<String, Pair<? extends PsiElement, PsiSubstitutor>> accessors = publicWriteAccessors(
-            psiType,
-            mapStructVersion,
-            mapstructUtil,
-            mappingMethod
-        );
-
-        if (mappingMethod != null) {
-            Stream<String> allDefinedMappingTargets = findAllDefinedMappingTargets( mappingMethod );
-            allDefinedMappingTargets.forEach( accessors::remove );
-        }
-
-        return asLookup(
-            accessors,
-            MapstructTargetReference::memberPsiType
-        );
-    }
-
-    /**
-     * Find all defined {@link Mapping#target()} for the given method
-     *
-     * @param method that needs to be checked
-     *
-     * @return see description
-     */
-    private Stream<String> findAllDefinedMappingTargets(@NotNull PsiMethod method) {
-        return findAllDefinedMappingAnnotations( method, mapStructVersion )
-            .map( psiAnnotation -> AnnotationUtil.getDeclaredStringAttributeValue( psiAnnotation, "target" ) )
-            .filter( Objects::nonNull )
-            .filter( s -> !s.isEmpty() );
-    }
-
-    @NotNull
-    @Override
     Object[] getVariantsInternal(@NotNull PsiMethod mappingMethod) {
         PsiType targetType = getRelevantType( mappingMethod );
         return targetType == null ? LookupElement.EMPTY_ARRAY : getVariantsInternal( targetType );
-    }
-
-    @Nullable
-    @Override
-    PsiType resolvedType() {
-        PsiElement element = resolve();
-
-        if ( element instanceof PsiMethod psiMethod ) {
-            return firstParameterPsiType( psiMethod );
-        }
-        else if ( element instanceof PsiParameter psiParameter ) {
-            return psiParameter.getType();
-        }
-        else if ( element instanceof PsiRecordComponent psiRecordComponent ) {
-            return psiRecordComponent.getType();
-        }
-        else if ( element instanceof PsiField psiField ) {
-            return psiField.getType();
-        }
-
-        return null;
     }
 
     /**
@@ -229,35 +78,4 @@ class MapstructTargetReference extends BaseMappingReference {
         return MapstructBaseReference.create( psiElement, MapstructTargetReference::new, true );
     }
 
-    private static PsiType memberPsiType(PsiElement psiMember) {
-        if ( psiMember instanceof PsiMethod psiMemberMethod ) {
-            return resolveMethodType( psiMemberMethod );
-        }
-        else if ( psiMember instanceof PsiVariable psiMemberVariable ) {
-            return psiMemberVariable.getType();
-        }
-        else {
-            return null;
-        }
-
-    }
-
-    private static boolean isCollectionGetterWriteAccessor(@NotNull PsiMethod method) {
-        if ( !isPublicNonStatic( method ) ) {
-            return false;
-        }
-        PsiParameterList parameterList = method.getParameterList();
-        if ( parameterList.getParametersCount() > 0 ) {
-            return false;
-        }
-        return TargetUtils.isMethodReturnTypeAssignableToCollectionOrMap( method );
-    }
-
-    private static PsiType resolveMethodType(PsiMethod psiMethod) {
-        PsiParameter[] psiParameters = psiMethod.getParameterList().getParameters();
-        if ( psiParameters.length == 0 ) {
-            return psiMethod.getReturnType();
-        }
-        return psiParameters[0].getType();
-    }
 }

--- a/src/main/java/org/mapstruct/intellij/inspection/TargetPropertyMappedMoreThanOnceInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/TargetPropertyMappedMoreThanOnceInspection.java
@@ -5,6 +5,14 @@
  */
 package org.mapstruct.intellij.inspection;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.intellij.codeInsight.AnnotationUtil;
 import com.intellij.codeInsight.intention.QuickFixFactory;
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement;
@@ -38,15 +46,10 @@ import org.mapstruct.intellij.util.MapStructVersion;
 import org.mapstruct.intellij.util.MapstructUtil;
 import org.mapstruct.intellij.util.TargetUtils;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import static com.intellij.codeInsight.AnnotationUtil.getStringAttributeValue;
-import static org.mapstruct.intellij.util.MapstructAnnotationUtils.extractMappingAnnotationsFromMappings;
+import static org.mapstruct.intellij.util.MapstructAnnotationUtils.extractRepeatableAnnotations;
+import static org.mapstruct.intellij.util.MapstructUtil.IGNORED_ANNOTATION_FQN;
+import static org.mapstruct.intellij.util.MapstructUtil.IGNORED_LIST_ANNOTATION_FQN;
 import static org.mapstruct.intellij.util.MapstructUtil.MAPPINGS_ANNOTATION_FQN;
 import static org.mapstruct.intellij.util.MapstructUtil.MAPPING_ANNOTATION_FQN;
 import static org.mapstruct.intellij.util.TargetUtils.getTargetType;
@@ -87,8 +90,15 @@ public class TargetPropertyMappedMoreThanOnceInspection extends InspectionBase {
                     handleMappingAnnotation( psiAnnotation, problemMap );
                 }
                 else if (MAPPINGS_ANNOTATION_FQN.equals( qualifiedName )) {
-                    extractMappingAnnotationsFromMappings( psiAnnotation )
+                    extractRepeatableAnnotations( psiAnnotation )
                             .forEach( a -> handleMappingAnnotation( a, problemMap ) );
+                }
+                else if ( IGNORED_ANNOTATION_FQN.equals( qualifiedName ) ) {
+                    handleIgnoredAnnotation( psiAnnotation, problemMap );
+                }
+                else if ( IGNORED_LIST_ANNOTATION_FQN.equals( qualifiedName ) ) {
+                    extractRepeatableAnnotations( psiAnnotation )
+                        .forEach( a -> handleIgnoredAnnotation( a, problemMap ) );
                 }
                 else {
                     // Handle annotations containing at least one Mapping annotation
@@ -152,6 +162,26 @@ public class TargetPropertyMappedMoreThanOnceInspection extends InspectionBase {
                 if (target != null && !target.equals( "." )) {
                     problemMap.computeIfAbsent( target, k -> new ArrayList<>() ).add( value );
                 }
+            }
+        }
+
+        private static void handleIgnoredAnnotation(PsiAnnotation psiAnnotation,
+                                                     Map<String, List<PsiElement>> problemMap) {
+            String prefixDot = TargetUtils.getIgnoredPrefix( psiAnnotation );
+
+            PsiAnnotationMemberValue targetsValue = psiAnnotation.findDeclaredAttributeValue( "targets" );
+            for ( PsiAnnotationMemberValue value : AnnotationUtil.arrayAttributeValues( targetsValue ) ) {
+                addIgnoredTarget( value, prefixDot, problemMap );
+            }
+
+        }
+
+        private static void addIgnoredTarget(PsiAnnotationMemberValue value, String prefixDot,
+                                              Map<String, List<PsiElement>> problemMap) {
+            String target = getStringAttributeValue( value );
+            if ( target != null && !target.isEmpty() ) {
+                problemMap.computeIfAbsent( prefixDot + target, k -> new ArrayList<>() )
+                    .add( value );
             }
         }
 

--- a/src/main/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspection.java
+++ b/src/main/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesInspection.java
@@ -46,6 +46,7 @@ import static org.mapstruct.intellij.util.MapstructUtil.getSourceParameters;
 import static org.mapstruct.intellij.util.SourceUtils.findAllSourceProperties;
 import static org.mapstruct.intellij.util.SourceUtils.getGenericTypes;
 import static org.mapstruct.intellij.util.TargetUtils.findAllDefinedMappingTargets;
+import static org.mapstruct.intellij.util.TargetUtils.findAllIgnoredTargets;
 import static org.mapstruct.intellij.util.TargetUtils.findAllSourcePropertiesForCurrentTarget;
 import static org.mapstruct.intellij.util.TargetUtils.findAllTargetProperties;
 import static org.mapstruct.intellij.util.TargetUtils.getTargetType;
@@ -116,6 +117,12 @@ public class UnmappedTargetPropertiesInspection extends InspectionBase {
                 .map( MyJavaElementVisitor::getBaseTarget )
                 .collect( Collectors.toSet() );
             allTargetProperties.removeAll( definedTargets );
+
+            // find and remove all @Ignored targets
+            Set<String> ignoredTargets = findAllIgnoredTargets( method )
+                .map( MyJavaElementVisitor::getBaseTarget )
+                .collect( Collectors.toSet() );
+            allTargetProperties.removeAll( ignoredTargets );
 
             // find and remove all inherited target properties
             Set<String> inheritedTargetProperties = findInheritedTargetProperties( method, mapStructVersion )

--- a/src/main/java/org/mapstruct/intellij/util/MapStructVersion.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapStructVersion.java
@@ -12,7 +12,8 @@ public enum MapStructVersion {
 
     V1_2_O( false, false ),
     V1_3_O( true, false ),
-    V1_4_O( true, true );
+    V1_4_O( true, true ),
+    V1_7_O( true, true );
 
     private final boolean builderSupported;
     private final boolean constructorSupported;

--- a/src/main/java/org/mapstruct/intellij/util/MapstructAnnotationUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructAnnotationUtils.java
@@ -298,26 +298,26 @@ public class MapstructAnnotationUtils {
                                                                           boolean includeMetaAnnotations) {
         //TODO cache
         PsiAnnotation mappings = findAnnotation( owner, true, MapstructUtil.MAPPINGS_ANNOTATION_FQN );
-        Stream<PsiAnnotation> mappingsAnnotations = extractMappingAnnotationsFromMappings( mappings );
+        Stream<PsiAnnotation> mappingsAnnotations = extractRepeatableAnnotations( mappings );
         Stream<PsiAnnotation> mappingAnnotations = findMappingAnnotations( owner, includeMetaAnnotations );
 
         return Stream.concat( mappingAnnotations, mappingsAnnotations );
     }
 
     @NotNull
-    public static Stream<PsiAnnotation> extractMappingAnnotationsFromMappings(@Nullable PsiAnnotation mappings) {
-        if (mappings == null) {
+    public static Stream<PsiAnnotation> extractRepeatableAnnotations(@Nullable PsiAnnotation annotation) {
+        if ( annotation == null ) {
             return Stream.empty();
         }
         //TODO maybe there is a better way to do this, but currently I don't have that much knowledge
-        PsiAnnotationMemberValue mappingsValue = mappings.findDeclaredAttributeValue( null );
-        if ( mappingsValue instanceof PsiArrayInitializerMemberValue mappingsArrayInitializerMemberValue) {
-            return Stream.of( mappingsArrayInitializerMemberValue
+        PsiAnnotationMemberValue value = annotation.findDeclaredAttributeValue( null );
+        if ( value instanceof PsiArrayInitializerMemberValue arrayInitializerMemberValue ) {
+            return Stream.of( arrayInitializerMemberValue
                             .getInitializers() )
-                    .filter( MapstructAnnotationUtils::isMappingPsiAnnotation )
+                    .filter( PsiAnnotation.class::isInstance )
                     .map( PsiAnnotation.class::cast );
         }
-        else if ( mappingsValue instanceof PsiAnnotation mappingsAnnotation ) {
+        else if ( value instanceof PsiAnnotation mappingsAnnotation ) {
             return Stream.of( mappingsAnnotation );
         }
         return Stream.empty();
@@ -394,17 +394,6 @@ public class MapstructAnnotationUtils {
     private static Stream<PsiAnnotation> findValueMappingAnnotations(@NotNull PsiMethod method) {
         return Stream.of( method.getModifierList().getAnnotations() )
             .filter( MapstructAnnotationUtils::isValueMappingAnnotation );
-    }
-
-    /**
-     * @param memberValue that needs to be checked
-     *
-     * @return {@code true} if the {@code memberValue} is the {@link org.mapstruct.Mapping} {@link PsiAnnotation},
-     * {@code false} otherwise
-     */
-    private static boolean isMappingPsiAnnotation(PsiAnnotationMemberValue memberValue) {
-        return memberValue instanceof PsiAnnotation
-            && isMappingAnnotation( (PsiAnnotation) memberValue );
     }
 
     /**

--- a/src/main/java/org/mapstruct/intellij/util/MapstructElementUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructElementUtils.java
@@ -43,6 +43,15 @@ public final class MapstructElementUtils {
     }
 
     /**
+     * @param parameterName the name of the parameter in the {@code @Ignored} annotation
+     *
+     * @return an element pattern for a parameter in the {@code @Ignored} annotation
+     */
+    public static PsiJavaElementPattern.Capture<PsiElement> ignoredElementPattern(String parameterName) {
+        return elementPattern( parameterName, MapstructUtil.IGNORED_ANNOTATION_FQN );
+    }
+
+    /**
      * @param parameterName the name of the parameter in the {@code @Mapper} annotation
      *
      * @return an element pattern for a parameter in the {@code @Mapper} annotation

--- a/src/main/java/org/mapstruct/intellij/util/MapstructKotlinElementUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructKotlinElementUtils.java
@@ -62,6 +62,18 @@ public final class MapstructKotlinElementUtils {
         );
     }
 
+    /**
+     * @param parameterName the name of the parameter in the {@code @Ignored} annotation
+     *
+     * @return an element pattern for a parameter in the {@code @Ignored} annotation
+     */
+    public static KotlinElementPattern.Capture<? extends PsiElement> ignoredElementPattern(String parameterName) {
+        return elementPattern(
+            parameterName,
+            MapstructUtil.IGNORED_ANNOTATION_FQN
+        );
+    }
+
     private static KotlinElementPattern.Capture<? extends PsiElement> elementPattern(String parameterName,
         String annotationFQN,
         String annotationHolderFQN

--- a/src/main/java/org/mapstruct/intellij/util/MapstructKotlinElementUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructKotlinElementUtils.java
@@ -70,7 +70,8 @@ public final class MapstructKotlinElementUtils {
     public static KotlinElementPattern.Capture<? extends PsiElement> ignoredElementPattern(String parameterName) {
         return elementPattern(
             parameterName,
-            MapstructUtil.IGNORED_ANNOTATION_FQN
+            MapstructUtil.IGNORED_ANNOTATION_FQN,
+            MapstructUtil.IGNORED_LIST_ANNOTATION_FQN
         );
     }
 

--- a/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
@@ -53,6 +53,8 @@ import org.mapstruct.BeanMapping;
 import org.mapstruct.Builder;
 import org.mapstruct.Context;
 import org.mapstruct.EnumMapping;
+import org.mapstruct.Ignored;
+import org.mapstruct.IgnoredList;
 import org.mapstruct.InheritConfiguration;
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
@@ -97,6 +99,9 @@ public class MapstructUtil {
     public static final String INHERIT_INVERSE_CONFIGURATION_FQN = InheritInverseConfiguration.class.getName();
 
     public static final String MAPPINGS_ANNOTATION_FQN = Mappings.class.getName();
+
+    public static final String IGNORED_ANNOTATION_FQN = Ignored.class.getName();
+    public static final String IGNORED_LIST_ANNOTATION_FQN = IgnoredList.class.getName();
 
     static final String VALUE_MAPPING_ANNOTATION_FQN = ValueMapping.class.getName();
     static final String VALUE_MAPPINGS_ANNOTATION_FQN = ValueMappings.class.getName();
@@ -567,12 +572,16 @@ public class MapstructUtil {
         }
         return CachedValuesManager.getManager( module.getProject() ).getCachedValue( module, () -> {
             MapStructVersion mapStructVersion;
-            if ( JavaPsiFacade.getInstance( module.getProject() )
-                .findClass( ENUM_MAPPING_ANNOTATION_FQN, module.getModuleRuntimeScope( false ) ) != null ) {
+            JavaPsiFacade javaPsiFacade = JavaPsiFacade.getInstance( module.getProject() );
+            GlobalSearchScope moduleRuntimeScope = module.getModuleRuntimeScope( false );
+            if ( javaPsiFacade.findClass( IGNORED_ANNOTATION_FQN, moduleRuntimeScope ) != null ) {
+                mapStructVersion = MapStructVersion.V1_7_O;
+            }
+            else if ( javaPsiFacade.findClass( ENUM_MAPPING_ANNOTATION_FQN, moduleRuntimeScope ) != null ) {
                 mapStructVersion = MapStructVersion.V1_4_O;
             }
-            else if ( JavaPsiFacade.getInstance( module.getProject() )
-                .findClass( BUILDER_ANNOTATION_FQN, module.getModuleRuntimeScope( false ) ) != null ) {
+            else if ( javaPsiFacade
+                .findClass( BUILDER_ANNOTATION_FQN, moduleRuntimeScope ) != null ) {
                 mapStructVersion = MapStructVersion.V1_3_O;
             }
             else {

--- a/src/main/java/org/mapstruct/intellij/util/TargetUtils.java
+++ b/src/main/java/org/mapstruct/intellij/util/TargetUtils.java
@@ -431,6 +431,58 @@ public class TargetUtils {
     }
 
     /**
+     * Find all target properties that are ignored via {@link org.mapstruct.Ignored} annotations for the given method.
+     * This considers both directly placed {@code @Ignored} annotations and those wrapped in {@code @IgnoredList},
+     * and prepends the {@code prefix} attribute value (if any) to each target.
+     *
+     * @param method that needs to be checked
+     *
+     * @return a stream of all ignored target property names (with prefix applied)
+     */
+    @NotNull
+    public static Stream<String> findAllIgnoredTargets(@NotNull PsiMethod method) {
+        Stream<PsiAnnotation> ignoredAnnotations = findIgnoredAnnotations( method );
+        return ignoredAnnotations.flatMap( TargetUtils::extractIgnoredTargets );
+    }
+
+    @NotNull
+    private static Stream<PsiAnnotation> findIgnoredAnnotations(@NotNull PsiMethod method) {
+        PsiAnnotation ignoredList = AnnotationUtil.findAnnotation(
+            method,
+            true,
+            MapstructUtil.IGNORED_LIST_ANNOTATION_FQN
+        );
+
+        Stream<PsiAnnotation> fromList = MapstructAnnotationUtils.extractRepeatableAnnotations( ignoredList );
+
+        Stream<PsiAnnotation> direct = Stream.of( method.getModifierList().getAnnotations() )
+            .filter( a -> MapstructUtil.IGNORED_ANNOTATION_FQN.equals( a.getQualifiedName() ) );
+
+        return Stream.concat( direct, fromList );
+    }
+
+    @NotNull
+    private static Stream<String> extractIgnoredTargets(@NotNull PsiAnnotation ignoredAnnotation) {
+
+        String prefixDot = getIgnoredPrefix( ignoredAnnotation );
+
+        return AnnotationUtil.arrayAttributeValues( ignoredAnnotation.findDeclaredAttributeValue( "targets" ) )
+            .stream()
+            .map( AnnotationUtil::getStringAttributeValue )
+            .filter( Objects::nonNull )
+            .filter( s -> !s.isEmpty() )
+            .map( target -> prefixDot + target );
+    }
+
+    public static String getIgnoredPrefix(@Nullable PsiAnnotation ignoredAnnotation) {
+        if ( ignoredAnnotation == null ) {
+            return "";
+        }
+        String prefix = AnnotationUtil.getDeclaredStringAttributeValue( ignoredAnnotation, "prefix" );
+        return ( prefix != null && !prefix.isEmpty() ) ? prefix + "." : "";
+    }
+
+    /**
      * Find all implicit source properties for all targets mapping to the current target, i.e. ".".
      *
      * @param method that needs to be checked

--- a/src/main/java/org/mapstruct/intellij/util/patterns/KotlinElementPattern.java
+++ b/src/main/java/org/mapstruct/intellij/util/patterns/KotlinElementPattern.java
@@ -37,12 +37,14 @@ public class KotlinElementPattern<T extends PsiElement, Self extends KotlinEleme
 
         KtValueArgumentPattern ktValueArgumentPattern = ktValueArgument().withName( parameterName );
         return withElementType( KtStubElementTypes.STRING_TEMPLATE ).andOr(
-            withParent(
+            withAncestor(
+                2,
                 ktValueArgumentPattern
                     .withAncestor( 5, ktAnnotation().qName( annotationHolderQualifiedName ) )
             ),
 
-            withParent(
+            withAncestor(
+                2,
                 ktValueArgumentPattern
                     .withSuperParent( 2, ktAnnotation().qName( annotationQualifiedName ) )
             )

--- a/src/test/java/org/mapstruct/intellij/MapstructCompletionTestCase.java
+++ b/src/test/java/org/mapstruct/intellij/MapstructCompletionTestCase.java
@@ -271,6 +271,20 @@ public class MapstructCompletionTestCase extends MapstructBaseCompletionTestCase
         assertCarDtoAutoComplete();
     }
 
+    public void testCarMapperReturnTargetCarDtoWithIgnored() {
+        configureByTestName();
+        assertThat( myItems )
+            .extracting( LookupElement::getLookupString )
+            .containsExactlyInAnyOrder(
+                "manufacturingYear",
+                "myDriver",
+                "passengers",
+                "price",
+                "category",
+                "available"
+            );
+    }
+
     public void testCarMapperReturnTargetFluentCarDto() {
         configureByTestName();
         assertCarDtoAutoComplete();

--- a/src/test/java/org/mapstruct/intellij/completion/IgnoredTargetsCompletionTestCase.java
+++ b/src/test/java/org/mapstruct/intellij/completion/IgnoredTargetsCompletionTestCase.java
@@ -173,4 +173,37 @@ public class IgnoredTargetsCompletionTestCase extends MapstructBaseCompletionTes
                 "available"
             );
     }
+
+    public void testIgnoredTargetsWithIgnoredList() {
+        configureByTestName();
+        assertThat( myItems )
+            .extracting( LookupElement::getLookupString )
+            .containsExactlyInAnyOrder(
+                "manufacturingYear",
+                "myDriver",
+                "passengers",
+                "price",
+                "category",
+                "available"
+            );
+    }
+
+    public void testIgnoredTargetsNoPrefixKotlin() {
+        configureByFile( "/" + getTestName( false ) + ".kt" );
+        assertCarDtoAutoComplete();
+    }
+
+    public void testIgnoredTargetsWithIgnoredListKotlin() {
+        configureByFile( "/" + getTestName( false ) + ".kt" );
+        assertThat( myItems )
+            .extracting( LookupElement::getLookupString )
+            .containsExactlyInAnyOrder(
+                "manufacturingYear",
+                "myDriver",
+                "passengers",
+                "price",
+                "category",
+                "available"
+            );
+    }
 }

--- a/src/test/java/org/mapstruct/intellij/completion/IgnoredTargetsCompletionTestCase.java
+++ b/src/test/java/org/mapstruct/intellij/completion/IgnoredTargetsCompletionTestCase.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.intellij.completion;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiReference;
+import org.mapstruct.intellij.MapstructBaseCompletionTestCase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class IgnoredTargetsCompletionTestCase extends MapstructBaseCompletionTestCase {
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/completion/ignored";
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        addDirectoryToProject( "../../mapping/dto" );
+    }
+
+    private void assertCarDtoAutoComplete() {
+        assertThat( myItems )
+            .extracting( LookupElement::getLookupString )
+            .containsExactlyInAnyOrder(
+                "make",
+                "seatCount",
+                "manufacturingYear",
+                "myDriver",
+                "passengers",
+                "price",
+                "category",
+                "available"
+            );
+    }
+
+    public void testIgnoredTargetsNoPrefix() {
+        configureByTestName();
+        assertCarDtoAutoComplete();
+    }
+
+    public void testIgnoredTargetsWithPrefix() {
+        configureByTestName();
+        assertCarDtoAutoComplete();
+    }
+
+    public void testIgnoredTargetsMultipleTargets() {
+        configureByTestName();
+        assertThat( myItems )
+            .extracting( LookupElement::getLookupString )
+            .containsExactlyInAnyOrder(
+                "manufacturingYear",
+                "myDriver",
+                "passengers",
+                "price",
+                "category",
+                "available"
+            );
+    }
+
+    public void testIgnoredTargetsWithPrefixMultipleTargets() {
+        configureByTestName();
+        assertThat( myItems )
+            .extracting( LookupElement::getLookupString )
+            .containsExactlyInAnyOrder(
+                "seatCount",
+                "manufacturingYear",
+                "myDriver",
+                "passengers",
+                "price",
+                "category",
+                "available"
+            );
+    }
+
+    public void testIgnoredTargetsWithMapping() {
+        configureByTestName();
+        assertThat( myItems )
+            .extracting( LookupElement::getLookupString )
+            .containsExactlyInAnyOrder(
+                "manufacturingYear",
+                "myDriver",
+                "passengers",
+                "price",
+                "category",
+                "available"
+            );
+    }
+
+    public void testIgnoredTargetsWithPrefixAndMapping() {
+        configureByTestName();
+        assertThat( myItems )
+            .extracting( LookupElement::getLookupString )
+            .containsExactlyInAnyOrder(
+                "manufacturingYear",
+                "myDriver",
+                "passengers",
+                "price",
+                "category",
+                "available"
+            );
+    }
+
+    public void testIgnoredTargetsSingleNoArray() {
+        configureByTestName();
+        assertCarDtoAutoComplete();
+    }
+
+    public void testIgnoredTargetsReferenceTarget() {
+        myFixture.configureByFile( "IgnoredTargetsReferenceTarget.java" );
+        PsiElement reference = myFixture.getElementAtCaret();
+
+        assertThat( reference )
+            .isInstanceOfSatisfying( PsiMethod.class, method -> {
+                assertThat( method.getName() ).isEqualTo( "setSeatCount" );
+            } );
+    }
+
+    public void testIgnoredTargetsReferenceTargetWithPrefix() {
+        myFixture.configureByFile( "IgnoredTargetsReferenceTargetWithPrefix.java" );
+        PsiElement reference = myFixture.getElementAtCaret();
+
+        assertThat( reference )
+            .isInstanceOfSatisfying( PsiMethod.class, method -> {
+                assertThat( method.getName() ).isEqualTo( "setMake" );
+            } );
+    }
+
+    public void testIgnoredTargetsReferenceUnknownTarget() {
+        myFixture.configureByFile( "IgnoredTargetsReferenceUnknownTarget.java" );
+        PsiReference reference = myFixture.getFile().findReferenceAt( myFixture.getCaretOffset() );
+        assertThat( reference ).isNotNull();
+        assertThat( reference.resolve() ).isNull();
+    }
+
+    public void testIgnoredTargetsReferenceNestedTarget() {
+        myFixture.configureByFile( "IgnoredTargetsReferenceNestedTarget.java" );
+        PsiElement reference = myFixture.getElementAtCaret();
+
+        assertThat( reference )
+            .isInstanceOfSatisfying( PsiMethod.class, method -> {
+                assertThat( method.getName() ).isEqualTo( "setName" );
+            } );
+    }
+
+    public void testIgnoredTargetsWithInvalidPrefix() {
+        myFixture.configureByFile( "IgnoredTargetsWithInvalidPrefix.java" );
+        complete();
+        assertThat( myItems ).isEmpty();
+    }
+
+    public void testIgnoredTargetsMultipleAnnotations() {
+        configureByTestName();
+        assertThat( myItems )
+            .extracting( LookupElement::getLookupString )
+            .containsExactlyInAnyOrder(
+                "manufacturingYear",
+                "myDriver",
+                "passengers",
+                "price",
+                "category",
+                "available"
+            );
+    }
+}

--- a/src/test/java/org/mapstruct/intellij/inspection/MapstructReferenceInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/MapstructReferenceInspectionTest.java
@@ -49,4 +49,8 @@ public class MapstructReferenceInspectionTest extends BaseInspectionTest {
     public void testUnknownQualifiedByNameReferenceReference() {
         doTest();
     }
+
+    public void testUnknownIgnoredTargetReference() {
+        doTest();
+    }
 }

--- a/src/test/java/org/mapstruct/intellij/inspection/TargetPropertyMappedMoreThanOnceInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/TargetPropertyMappedMoreThanOnceInspectionTest.java
@@ -24,6 +24,10 @@ public class TargetPropertyMappedMoreThanOnceInspectionTest extends BaseInspecti
         return TargetPropertyMappedMoreThanOnceInspection.class;
     }
 
+    public void testTargetPropertyMappedMoreThanOnceWithIgnored() {
+        doTest();
+    }
+
     public void testTargetPropertyMappedMoreThanOnce() {
         doTest();
         String testName = getTestName( false );

--- a/src/test/java/org/mapstruct/intellij/inspection/TargetPropertyMappedMoreThanOnceInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/TargetPropertyMappedMoreThanOnceInspectionTest.java
@@ -28,6 +28,10 @@ public class TargetPropertyMappedMoreThanOnceInspectionTest extends BaseInspecti
         doTest();
     }
 
+    public void testTargetPropertyMappedMoreThanOnceWithIgnoredList() {
+        doTest();
+    }
+
     public void testTargetPropertyMappedMoreThanOnce() {
         doTest();
         String testName = getTestName( false );

--- a/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesWithIgnoredInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/UnmappedTargetPropertiesWithIgnoredInspectionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.intellij.inspection;
+
+import java.util.List;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import org.jetbrains.annotations.NotNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class UnmappedTargetPropertiesWithIgnoredInspectionTest extends BaseInspectionTest {
+
+    @NotNull
+    @Override
+    protected Class<UnmappedTargetPropertiesInspection> getInspection() {
+        return UnmappedTargetPropertiesInspection.class;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        myFixture.copyFileToProject(
+            "UnmappedTargetPropertiesData.java",
+            "org/example/data/UnmappedTargetPropertiesData.java"
+        );
+    }
+
+    public void testUnmappedTargetPropertiesWithIgnored() {
+        doTest();
+        List<IntentionAction> allQuickFixes = myFixture.getAllQuickFixes();
+
+        assertThat( allQuickFixes )
+            .extracting( IntentionAction::getText )
+            .as( "Intent Text" )
+            .containsExactly(
+                "Ignore unmapped target property: 'moreTarget'",
+                "Add unmapped target property: 'moreTarget'"
+            );
+    }
+}

--- a/testData/completion/ignored/IgnoredTargetsMultipleAnnotations.java
+++ b/testData/completion/ignored/IgnoredTargetsMultipleAnnotations.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.example.dto.Car;
+import org.example.dto.CarDto;
+
+@Mapper
+public interface IgnoredTargetsMultipleAnnotations {
+
+    @Ignored(targets = { "make", "seatCount" })
+    @Ignored(targets = { "<caret>" })
+    CarDto carToCarDto(Car car);
+}

--- a/testData/completion/ignored/IgnoredTargetsMultipleTargets.java
+++ b/testData/completion/ignored/IgnoredTargetsMultipleTargets.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.example.dto.Car;
+import org.example.dto.CarDto;
+
+@Mapper
+public interface IgnoredTargetsMultipleTargets {
+
+    @Ignored(targets = { "make", "seatCount", "<caret>" })
+    CarDto carToCarDto(Car car);
+}

--- a/testData/completion/ignored/IgnoredTargetsNoPrefix.java
+++ b/testData/completion/ignored/IgnoredTargetsNoPrefix.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.example.dto.Car;
+import org.example.dto.CarDto;
+
+@Mapper
+public interface IgnoredTargetsNoPrefix {
+
+    @Ignored(targets = { "<caret>" })
+    CarDto carToCarDto(Car car);
+}

--- a/testData/completion/ignored/IgnoredTargetsNoPrefixKotlin.kt
+++ b/testData/completion/ignored/IgnoredTargetsNoPrefixKotlin.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex
+
+import org.mapstruct.Ignored
+import org.mapstruct.Mapper
+import org.example.dto.Car
+import org.example.dto.CarDtoKt
+
+@Mapper
+interface IgnoredTargetsNoPrefixKotlin {
+
+    @Ignored(targets = ["<caret>"])
+    fun carToCarDto(car: Car): CarDtoKt
+}

--- a/testData/completion/ignored/IgnoredTargetsReferenceNestedTarget.java
+++ b/testData/completion/ignored/IgnoredTargetsReferenceNestedTarget.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.example.dto.Car;
+import org.example.dto.CarDto;
+
+@Mapper
+public interface IgnoredTargetsReferenceNestedTarget {
+
+    @Ignored(targets = { "myDriver.name<caret>" })
+    CarDto carToCarDto(Car car);
+}

--- a/testData/completion/ignored/IgnoredTargetsReferenceTarget.java
+++ b/testData/completion/ignored/IgnoredTargetsReferenceTarget.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.example.dto.Car;
+import org.example.dto.CarDto;
+
+@Mapper
+public interface IgnoredTargetsReferenceTarget {
+
+    @Ignored(targets = { "seatCount<caret>" })
+    CarDto carToCarDto(Car car);
+}

--- a/testData/completion/ignored/IgnoredTargetsReferenceTargetWithPrefix.java
+++ b/testData/completion/ignored/IgnoredTargetsReferenceTargetWithPrefix.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.example.dto.Garage;
+import org.example.dto.GarageDto;
+
+@Mapper
+public interface IgnoredTargetsReferenceTargetWithPrefix {
+
+    @Ignored(prefix = "car", targets = { "make<caret>" })
+    GarageDto garageToGarageDto(Garage garage);
+}

--- a/testData/completion/ignored/IgnoredTargetsReferenceUnknownTarget.java
+++ b/testData/completion/ignored/IgnoredTargetsReferenceUnknownTarget.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.example.dto.Car;
+import org.example.dto.CarDto;
+
+@Mapper
+public interface IgnoredTargetsReferenceUnknownTarget {
+
+    @Ignored(targets = { "unknown<caret>" })
+    CarDto carToCarDto(Car car);
+}

--- a/testData/completion/ignored/IgnoredTargetsSingleNoArray.java
+++ b/testData/completion/ignored/IgnoredTargetsSingleNoArray.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.example.dto.Car;
+import org.example.dto.CarDto;
+
+@Mapper
+public interface IgnoredTargetsSingleNoArray {
+
+    @Ignored(targets = "<caret>")
+    CarDto carToCarDto(Car car);
+}

--- a/testData/completion/ignored/IgnoredTargetsWithIgnoredList.java
+++ b/testData/completion/ignored/IgnoredTargetsWithIgnoredList.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.IgnoredList;
+import org.mapstruct.Mapper;
+import org.example.dto.Car;
+import org.example.dto.CarDto;
+
+@Mapper
+public interface IgnoredTargetsWithIgnoredList {
+
+    @IgnoredList({
+        @Ignored(targets = { "make", "seatCount" }),
+        @Ignored(targets = { "<caret>" })
+    })
+    CarDto carToCarDto(Car car);
+}

--- a/testData/completion/ignored/IgnoredTargetsWithIgnoredListKotlin.kt
+++ b/testData/completion/ignored/IgnoredTargetsWithIgnoredListKotlin.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex
+
+import org.mapstruct.Ignored
+import org.mapstruct.IgnoredList
+import org.mapstruct.Mapper
+import org.example.dto.Car
+import org.example.dto.CarDtoKt
+
+@Mapper
+interface IgnoredTargetsWithIgnoredListKotlin {
+
+    @IgnoredList(
+        Ignored(targets = ["make", "seatCount"]),
+        Ignored(targets = ["<caret>"])
+    )
+    fun carToCarDto(car: Car): CarDtoKt
+}

--- a/testData/completion/ignored/IgnoredTargetsWithInvalidPrefix.java
+++ b/testData/completion/ignored/IgnoredTargetsWithInvalidPrefix.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.example.dto.Garage;
+import org.example.dto.GarageDto;
+
+@Mapper
+public interface IgnoredTargetsWithInvalidPrefix {
+
+    @Ignored(prefix = "nonExistent", targets = { "<caret>" })
+    GarageDto garageToGarageDto(Garage garage);
+}

--- a/testData/completion/ignored/IgnoredTargetsWithMapping.java
+++ b/testData/completion/ignored/IgnoredTargetsWithMapping.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.example.dto.Car;
+import org.example.dto.CarDto;
+
+@Mapper
+public interface IgnoredTargetsWithMapping {
+
+    @Ignored(targets = { "seatCount", "<caret>" })
+    @Mapping(target = "make", ignore = true)
+    CarDto carToCarDto(Car car);
+}

--- a/testData/completion/ignored/IgnoredTargetsWithPrefix.java
+++ b/testData/completion/ignored/IgnoredTargetsWithPrefix.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.example.dto.Garage;
+import org.example.dto.GarageDto;
+
+@Mapper
+public interface IgnoredTargetsWithPrefix {
+
+    @Ignored(prefix = "car", targets = { "<caret>" })
+    GarageDto garageToGarageDto(Garage garage);
+}

--- a/testData/completion/ignored/IgnoredTargetsWithPrefixAndMapping.java
+++ b/testData/completion/ignored/IgnoredTargetsWithPrefixAndMapping.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.example.dto.Garage;
+import org.example.dto.GarageDto;
+
+@Mapper
+public interface IgnoredTargetsWithPrefixAndMapping {
+
+    @Ignored(prefix = "car", targets = { "seatCount", "<caret>" })
+    @Mapping(target = "car.make", source = "car.make")
+    GarageDto garageToGarageDto(Garage garage);
+}

--- a/testData/completion/ignored/IgnoredTargetsWithPrefixMultipleTargets.java
+++ b/testData/completion/ignored/IgnoredTargetsWithPrefixMultipleTargets.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.example.dto.Garage;
+import org.example.dto.GarageDto;
+
+@Mapper
+public interface IgnoredTargetsWithPrefixMultipleTargets {
+
+    @Ignored(prefix = "car", targets = { "make", "<caret>" })
+    GarageDto garageToGarageDto(Garage garage);
+}

--- a/testData/inspection/TargetPropertyMappedMoreThanOnceWithIgnored.java
+++ b/testData/inspection/TargetPropertyMappedMoreThanOnceWithIgnored.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+class Source {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+
+class Target {
+    private String testName;
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public void setTestName(String testName) {
+        this.testName = testName;
+    }
+}
+
+class Inner {
+
+    private Target target;
+
+    public Target getTarget() {
+        return target;
+    }
+
+    public void setTarget(Target target) {
+        this.target = target;
+    }
+}
+
+@Mapper
+interface MappingAndIgnoredSameTargetMapper {
+
+    @Mapping(target = <error descr="Target property 'testName' must not be mapped more than once.">"testName"</error>, source = "name")
+    @Ignored(targets = { <error descr="Target property 'testName' must not be mapped more than once.">"testName"</error> })
+    Target map(Source source);
+}
+
+@Mapper
+interface IgnoredAndIgnoredSameTargetMapper {
+
+    @Ignored(targets = { <error descr="Target property 'testName' must not be mapped more than once.">"testName"</error> })
+    @Ignored(targets = { <error descr="Target property 'testName' must not be mapped more than once.">"testName"</error> })
+    Target map(Source source);
+}
+
+@Mapper
+interface IgnoredWithPrefixAndMappingSameTargetMapper {
+
+    @Mapping(target = <error descr="Target property 'target.testName' must not be mapped more than once.">"target.testName"</error>, source = "name")
+    @Ignored(prefix = "target", targets = { <error descr="Target property 'target.testName' must not be mapped more than once.">"testName"</error> })
+    Inner map(Source source);
+}
+
+@Mapper
+interface IgnoredNoConflictMapper {
+
+    @Mapping(target = "testName", source = "name")
+    @Ignored(targets = { "other" })
+    Target map(Source source);
+}
+
+@Mapper
+interface IgnoredWithPrefixNoConflictMapper {
+
+    @Mapping(target = "testName", source = "name")
+    @Ignored(prefix = "target", targets = { "testName" })
+    Inner map(Source source);
+}
+
+@Mapper
+interface IgnoredSingleValueAndMappingMapper {
+
+    @Mapping(target = <error descr="Target property 'testName' must not be mapped more than once.">"testName"</error>, source = "name")
+    @Ignored(targets = <error descr="Target property 'testName' must not be mapped more than once.">"testName"</error>)
+    Target map(Source source);
+}
+
+@Mapper
+interface MultipleTargetsInIgnoredMapper {
+
+    @Mapping(target = <error descr="Target property 'testName' must not be mapped more than once.">"testName"</error>, source = "name")
+    @Ignored(targets = { <error descr="Target property 'testName' must not be mapped more than once.">"testName"</error>, "other" })
+    Target map(Source source);
+}

--- a/testData/inspection/TargetPropertyMappedMoreThanOnceWithIgnoredList.java
+++ b/testData/inspection/TargetPropertyMappedMoreThanOnceWithIgnoredList.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Ignored;
+import org.mapstruct.IgnoredList;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+class Source {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+
+class Target {
+    private String testName;
+    private String moreTarget;
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public void setTestName(String testName) {
+        this.testName = testName;
+    }
+
+    public String getMoreTarget() {
+        return moreTarget;
+    }
+
+    public void setMoreTarget(String moreTarget) {
+        this.moreTarget = moreTarget;
+    }
+}
+
+@Mapper
+interface MappingAndIgnoredListSameTargetMapper {
+
+    @Mapping(target = <error descr="Target property 'testName' must not be mapped more than once.">"testName"</error>, source = "name")
+    @IgnoredList({
+        @Ignored(targets = { <error descr="Target property 'testName' must not be mapped more than once.">"testName"</error> })
+    })
+    Target map(Source source);
+}
+
+@Mapper
+interface IgnoredListDuplicateTargetMapper {
+
+    @IgnoredList({
+        @Ignored(targets = { <error descr="Target property 'testName' must not be mapped more than once.">"testName"</error> }),
+        @Ignored(targets = { <error descr="Target property 'testName' must not be mapped more than once.">"testName"</error> })
+    })
+    Target map(Source source);
+}
+
+@Mapper
+interface IgnoredListNoConflictMapper {
+
+    @IgnoredList({
+        @Ignored(targets = { "testName" }),
+        @Ignored(targets = { "moreTarget" })
+    })
+    Target map(Source source);
+}

--- a/testData/inspection/UnknownIgnoredTargetReference.java
+++ b/testData/inspection/UnknownIgnoredTargetReference.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+
+class Source {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+
+class Target {
+
+    private String testName;
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public void setTestName(String testName) {
+        this.testName = testName;
+    }
+}
+
+class Inner {
+
+    private Target target;
+
+    public Target getTarget() {
+        return target;
+    }
+
+    public void setTarget(Target target) {
+        this.target = target;
+    }
+}
+
+@Mapper
+interface SingleIgnoredMapper {
+
+    @Ignored(targets = { "<error descr="Unknown property 'name'">name</error>" })
+    Target map(Source source);
+}
+
+@Mapper
+interface ValidIgnoredMapper {
+
+    @Ignored(targets = { "testName" })
+    Target map(Source source);
+}
+
+@Mapper
+interface EmptyIgnoredMapper {
+
+    @Ignored(targets = { <error descr="Unknown property ''">""</error> })
+    Target map(Source source);
+}
+
+@Mapper
+interface MultipleIgnoredMapper {
+
+    @Ignored(targets = { "testName", "<error descr="Unknown property 'unknown'">unknown</error>" })
+    Target map(Source source);
+}
+
+@Mapper
+interface IgnoredWithPrefixMapper {
+
+    @Ignored(prefix = "target", targets = { "<error descr="Unknown property 'unknown'">unknown</error>" })
+    Inner map(Source source);
+}
+
+@Mapper
+interface ValidIgnoredWithPrefixMapper {
+
+    @Ignored(prefix = "target", targets = { "testName" })
+    Inner map(Source source);
+}
+
+@Mapper
+interface IgnoredNestedTargetMapper {
+
+    @Ignored(targets = { "target.<error descr="Unknown property 'unknown'">unknown</error>" })
+    Inner map(Source source);
+}
+
+@Mapper
+interface ValidIgnoredNestedTargetMapper {
+
+    @Ignored(targets = { "target.testName" })
+    Inner map(Source source);
+}
+
+@Mapper
+interface SingleNoArrayIgnoredMapper {
+
+    @Ignored(targets = "<error descr="Unknown property 'name'">name</error>")
+    Target map(Source source);
+}
+
+@Mapper
+interface IgnoredWithInvalidPrefixMapper {
+
+    @Ignored(prefix = "<error descr="Unknown property 'nonExistent'">nonExistent</error>", targets = { "<error descr="Unknown property 'foo'">foo</error>" })
+    Inner map(Source source);
+}

--- a/testData/inspection/UnmappedTargetPropertiesWithIgnored.java
+++ b/testData/inspection/UnmappedTargetPropertiesWithIgnored.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.example.data.UnmappedTargetPropertiesData.Target;
+import org.example.data.UnmappedTargetPropertiesData.Source;
+import org.example.data.UnmappedTargetPropertiesData.TargetWithInnerObject;
+
+@Mapper
+interface AllIgnoredMapper {
+
+    @Ignored(targets = { "testName", "moreTarget" })
+    Target map(Source source);
+}
+
+@Mapper
+interface PartiallyIgnoredMapper {
+
+    @Ignored(targets = { "testName" })
+    Target <warning descr="Unmapped target property: moreTarget">map</warning>(Source source);
+}
+
+@Mapper
+interface IgnoredAndMappedMapper {
+
+    @Ignored(targets = { "moreTarget" })
+    @Mapping(target = "testName", source = "name")
+    Target map(Source source);
+}
+
+@Mapper
+interface IgnoredWithPrefixMapper {
+
+    @Ignored(prefix = "testTarget", targets = { "testName", "moreTarget" })
+    TargetWithInnerObject map(Source source);
+}
+
+@Mapper
+interface MultipleIgnoredAnnotationsMapper {
+
+    @Ignored(targets = { "testName" })
+    @Ignored(targets = { "moreTarget" })
+    Target map(Source source);
+}
+
+@Mapper
+interface IgnoredWithPrefixAndMappingMapper {
+
+    @Ignored(prefix = "testTarget", targets = { "moreTarget" })
+    @Mapping(target = "testTarget.testName", source = "name")
+    TargetWithInnerObject map(Source source);
+}

--- a/testData/mapping/CarMapperReturnTargetCarDtoWithIgnored.java
+++ b/testData/mapping/CarMapperReturnTargetCarDtoWithIgnored.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.complex;
+
+import org.mapstruct.Ignored;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.example.dto.CarDto;
+import org.example.dto.Car;
+
+@Mapper
+public interface CarMapperReturnTargetCarDtoWithIgnored {
+
+    @Ignored(targets = { "seatCount", "make" })
+    @Mapping(source = "manufacturingDate", target = "<caret>")
+    CarDto carToCarDto(Car car);
+}


### PR DESCRIPTION
## Summary

Closes #237, closes #238

Add support for the `@Ignored` annotation introduced in MapStruct 1.7:

- **Code completion** for `@Ignored(targets=...)` with `prefix` support — correctly excludes targets already defined in other `@Ignored` and `@Mapping` annotations on the same method
- **Go-to-declaration** and **find usages** for ignored target properties
- **UnmappedTargetPropertiesInspection** considers `@Ignored` targets as mapped
- **TargetPropertyMappedMoreThanOnceInspection** detects conflicts between `@Mapping` and `@Ignored` targeting the same property
- **Unknown target reference inspection** for `@Ignored` targets

Also refactors `MapstructTargetReference` by extracting shared logic into `BaseTargetReference`, reused by both `MapstructTargetReference` and the new `MapstructIgnoredTargetReference`. Generalizes `extractMappingAnnotationsFromMappings` to `extractRepeatableAnnotations` for reuse with `@IgnoredList`.

## Test plan

- [x] `IgnoredTargetsCompletionTestCase` — completion with/without prefix, multiple targets, multiple annotations, invalid prefix, combined with `@Mapping`
- [x] `UnmappedTargetPropertiesWithIgnoredInspectionTest` — unmapped properties inspection respects `@Ignored`
- [x] `TargetPropertyMappedMoreThanOnceInspectionTest` — detects `@Mapping`/`@Ignored` conflicts
- [x] `MapstructReferenceInspectionTest` — unknown target reference for `@Ignored`
- [x] `MapstructCompletionTestCase` — completion with `@Ignored` present on method
- [x] Full build passes (`./gradlew build`)