### PR TITLE
Add idea 2026.1 to GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
           - { jdk: 21, idea: 2025.1 }
           - { jdk: 21, idea: 2025.2 }
           - { jdk: 21, idea: 2025.3 }
+          - { jdk: 21, idea: 2025.3 }
+          - { jdk: 21, idea: 2026.1 }
           - { jdk: 21, idea: LATEST-EAP-SNAPSHOT }
     name: 'IDEA ${{ matrix.version.idea }}'
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
           - { jdk: 21, idea: 2025.1 }
           - { jdk: 21, idea: 2025.2 }
           - { jdk: 21, idea: 2025.3 }
-          - { jdk: 21, idea: 2025.3 }
           - { jdk: 21, idea: 2026.1 }
           - { jdk: 21, idea: LATEST-EAP-SNAPSHOT }
     name: 'IDEA ${{ matrix.version.idea }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - { jdk: 21, idea: 2024.2 }
-          - { jdk: 21, idea: 2024.3 }
           - { jdk: 21, idea: 2025.1 }
           - { jdk: 21, idea: 2025.2 }
           - { jdk: 21, idea: 2025.3 }
@@ -34,7 +32,7 @@ jobs:
       - name: 'Generate coverage report'
         run: ./gradlew --warning-mode=all jacocoTestReport
       - name: 'Upload coverage to Codecov'
-        if: github.repository == 'mapstruct/mapstruct-idea' &&  matrix.version.idea  == '2024.2'
+        if: github.repository == 'mapstruct/mapstruct-idea' &&  matrix.version.idea  == '2025.1'
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,8 @@ import com.hierynomus.gradle.license.tasks.LicenseFormat
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
-    id("org.jetbrains.intellij.platform") version "2.10.5"
+    id('java')
+    id("org.jetbrains.intellij.platform") version "2.15.0"
     id("com.github.hierynomus.license") version "0.16.1"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -93,9 +93,12 @@ jacocoTestReport {
 }
 
 def versionToUse = System.getenv().getOrDefault( 'IDEA_VERSION', ideaVersion )
+def useIdeaInstaller = !versionToUse.containsIgnoreCase( "EAP" )
 dependencies {
     intellijPlatform {
-        intellijIdea(versionToUse)
+        intellijIdea(versionToUse) {
+            useInstaller = false
+        }
 
         bundledPlugin( 'com.intellij.java' )
         bundledPlugin( 'org.jetbrains.kotlin' )

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ def useIdeaInstaller = !versionToUse.containsIgnoreCase( "EAP" )
 dependencies {
     intellijPlatform {
         intellijIdea(versionToUse) {
-            useInstaller = false
+            useInstaller = useIdeaInstaller
         }
 
         bundledPlugin( 'com.intellij.java' )

--- a/build.gradle
+++ b/build.gradle
@@ -103,8 +103,8 @@ dependencies {
         bundledPlugin( 'com.intellij.java' )
         bundledPlugin( 'org.jetbrains.kotlin' )
 
-        testFramework(TestFrameworkType.Platform.INSTANCE)
-        testFramework(TestFrameworkType.Plugin.Java.INSTANCE)
+        testFramework( TestFrameworkType.Platform.INSTANCE )
+        testFramework( TestFrameworkType.Plugin.Java.INSTANCE )
     }
     implementation('org.mapstruct:mapstruct:1.5.3.Final')
     testImplementation(platform('org.junit:junit-bom:5.11.0'))

--- a/build.gradle
+++ b/build.gradle
@@ -100,8 +100,8 @@ dependencies {
         bundledPlugin( 'com.intellij.java' )
         bundledPlugin( 'org.jetbrains.kotlin' )
 
-        testFramework( TestFrameworkType.Platform.INSTANCE )
-        testFramework( TestFrameworkType.Bundled.INSTANCE )
+        testFramework(TestFrameworkType.Platform.INSTANCE)
+        testFramework(TestFrameworkType.Plugin.Java.INSTANCE)
     }
     implementation('org.mapstruct:mapstruct:1.5.3.Final')
     testImplementation(platform('org.junit:junit-bom:5.11.0'))

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ intellijPlatform {
     projectName = 'MapStruct-Intellij-Plugin'
     pluginConfiguration {
         ideaVersion {
-            sinceBuild = "242"
+            sinceBuild = "251"
             untilBuild = provider { null } as Provider<? extends String>
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -93,18 +93,9 @@ jacocoTestReport {
 }
 
 def versionToUse = System.getenv().getOrDefault( 'IDEA_VERSION', ideaVersion )
-def useIdeaInstaller = !versionToUse.containsIgnoreCase( "EAP" )
 dependencies {
     intellijPlatform {
-        // When versionToUse is 2025.3 or later then there is only a single distribution of IntelliJ
-        // This comparison can be removed if the oldest supported version of idea is 2025.3 (253) or later
-        if (('2025.3' <=> versionToUse) <= 0 ){
-            intellijIdea(versionToUse) {
-                useInstaller = useIdeaInstaller
-            }
-        } else {
-            ideaType == 'IC' ? intellijIdeaCommunity(versionToUse, useIdeaInstaller) : intellijIdeaUltimate(versionToUse, useIdeaInstaller)
-        }
+        intellijIdea(versionToUse)
 
         bundledPlugin( 'com.intellij.java' )
         bundledPlugin( 'org.jetbrains.kotlin' )

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
 
-ideaVersion = 2024.2
+ideaVersion = 2025.1
 sources = true
 runGenerators = true
 org.gradle.jvmargs=-Xmx1024m

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,6 @@
 # https://www.jetbrains.com/intellij-repository/snapshots
 
 ideaVersion = 2024.2
-ideaType = IC
 sources = true
 runGenerators = true
 org.gradle.jvmargs=-Xmx1024m

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -24,7 +24,7 @@
   <vendor url="https://www.mapstruct.org">MapStruct</vendor>
 
   <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-  <idea-version since-build="242"/>
+  <idea-version since-build="251"/>
 
   <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
        on how to target different products -->


### PR DESCRIPTION
I added IDEA2026.1 to the GitHub workflow.
For this I upgraded the `org.jetbrains.intellij.platform plugin` to `2.15.0`. This makes the workaround for older versions of idea obsolete.
In addition I replaced `testFramework( TestFrameworkType.Bundled.INSTANCE )` (should not be used see [https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-types.html#TestFrameworkType-Platform](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-types.html#TestFrameworkType-Platform)) with `testFramework(TestFrameworkType.Plugin.Java.INSTANCE)`. As a reference I used [github.com/JetBrains/intellij-sdk-code-samples/blob/main/simple_language_plugin/build.gradle.kts](github.com/JetBrains/intellij-sdk-code-samples/blob/main/simple_language_plugin/build.gradle.kts)