### PR TITLE
upgrade assertJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter-api')
     testImplementation('org.junit.jupiter:junit-jupiter-engine')
     testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
-    testImplementation('org.assertj:assertj-core:3.26.3')
+    testImplementation('org.assertj:assertj-core:3.27.7')
     testImplementation('org.apache.commons:commons-text:1.15.0')
     testImplementation( 'junit:junit:4.13.2' )
     testRuntimeOnly('org.immutables:value:2.10.1')


### PR DESCRIPTION
The current version has a [CVE-2026-24400](https://www.cve.org/CVERecord?id=CVE-2026-24400). 
I don't think this project is effected, still should be upgraded.