### PR TITLE
fix jacocoTestReport generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,6 @@ checkstyle {
 }
 
 jacocoTestReport {
-    classDirectories.setFrom(instrumentCode)
     reports {
         xml.required = true
         html.required = true


### PR DESCRIPTION
@filiphr It looks like coverage reporting has been broken for a while. I traced the issue back to the `jacocoTestReport` job.

We’re not actually using `instrumentCode`, but it was still configured for that job.