### PR TITLE
Improve mapstruct version detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,16 +124,9 @@ tasks.register('libs', Sync) {
         include('mapstruct-intellij-*.jar')
         include('MapStruct-Intellij-*.jar')
     }
-    rename('mapstruct-1.5.3.Final.jar', 'mapstruct.jar')
 }
 
-tasks.register('testLibs', Sync) {
-    from(configurations.testRuntimeClasspath)
-    into(layout.buildDirectory.dir("test-libs"))
-    rename('value-2.10.1.jar', 'immutables.jar')
-}
-
-test.dependsOn( libs, testLibs )
+test.dependsOn( libs )
 prepareSandbox.dependsOn( libs )
 composedJar.dependsOn( libs )
 

--- a/src/main/java/org/mapstruct/intellij/util/MapStructVersion.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapStructVersion.java
@@ -17,8 +17,8 @@ public class MapStructVersion implements Comparable<MapStructVersion> {
 
     public static final MapStructVersion DEFAULT_VERSION = fromVersionString( "1.2.0.Final" );
 
-    private static final MapStructVersion BUILDER_SUPPORTED = fromVersionString( "1.3.0.Final" );
-    private static final MapStructVersion CONSTRUCTOR_SUPPORTED = fromVersionString( "1.4.0.Final" );
+    private static final MapStructVersion BUILDER_SUPPORTED = fromVersionString( "1.3.0.Beta1" );
+    private static final MapStructVersion CONSTRUCTOR_SUPPORTED = fromVersionString( "1.4.0.Beta1" );
 
     private final int major;
     private final int minor;

--- a/src/main/java/org/mapstruct/intellij/util/MapStructVersion.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapStructVersion.java
@@ -5,28 +5,107 @@
  */
 package org.mapstruct.intellij.util;
 
+import java.util.Comparator;
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
+
 /**
  * @author Filip Hrisafov
  */
-public enum MapStructVersion {
+public class MapStructVersion implements Comparable<MapStructVersion> {
 
-    V1_2_O( false, false ),
-    V1_3_O( true, false ),
-    V1_4_O( true, true );
+    public static final MapStructVersion DEFAULT_VERSION = fromVersionString( "1.2.0.Final" );
 
-    private final boolean builderSupported;
-    private final boolean constructorSupported;
+    private static final MapStructVersion BUILDER_SUPPORTED = fromVersionString( "1.3.0.Final" );
+    private static final MapStructVersion CONSTRUCTOR_SUPPORTED = fromVersionString( "1.4.0.Final" );
 
-    MapStructVersion(boolean builderSupported, boolean constructorSupported) {
-        this.builderSupported = builderSupported;
-        this.constructorSupported = constructorSupported;
+    private final int major;
+    private final int minor;
+    private final int patch;
+    private final ReleaseState releaseState;
+    private final int releaseStateVersion;
+
+    @Override
+    public int compareTo(@NotNull MapStructVersion other) {
+        return Comparator
+                .comparingInt( (MapStructVersion v) -> v.major )
+                .thenComparingInt( v -> v.minor )
+                .thenComparingInt( v -> v.patch )
+                .thenComparing( v -> v.releaseState )
+                .thenComparingInt( v -> v.releaseStateVersion )
+                .compare( this, other );
+    }
+
+    public enum ReleaseState {
+        ALPHA,
+        BETA,
+        RELEASE_CANDIDATE,
+        FINAL
+    }
+
+    public MapStructVersion(int major, int minor, int patch, ReleaseState releaseState,
+                            int releaseStateVersion) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+        this.releaseState = releaseState;
+        this.releaseStateVersion = releaseStateVersion;
+    }
+
+    public static MapStructVersion fromVersionString( String version ) {
+        if ( version == null ) {
+            return DEFAULT_VERSION;
+        }
+        try {
+            String[] s = version.split( "\\." );
+            int majorVersion = Integer.parseInt( s[0] );
+            int minorVersion = Integer.parseInt( s[1] );
+            int patch = Integer.parseInt( s[2] );
+            ReleaseState releaseState = ReleaseState.FINAL;
+            int releaseStateVersion = 0;
+            if ( s.length > 3 ) {
+                String releaseStateString = s[3];
+                if ( releaseStateString.startsWith( "Alpha" ) ) {
+                    releaseState = ReleaseState.ALPHA;
+                    releaseStateVersion = Integer.parseInt( releaseStateString.substring( 5 ) );
+                }
+                else if ( releaseStateString.startsWith( "Beta" ) ) {
+                    releaseState = ReleaseState.BETA;
+                    releaseStateVersion = Integer.parseInt( releaseStateString.substring( 4 ) );
+                }
+                else if ( releaseStateString.startsWith( "CR" ) ) {
+                    releaseState = ReleaseState.RELEASE_CANDIDATE;
+                    releaseStateVersion = Integer.parseInt( releaseStateString.substring( 2 ) );
+                }
+            }
+            return new MapStructVersion(majorVersion, minorVersion, patch, releaseState, releaseStateVersion);
+        }
+        catch ( RuntimeException e ) {
+            return DEFAULT_VERSION;
+        }
     }
 
     public boolean isBuilderSupported() {
-        return builderSupported;
+        return compareTo( BUILDER_SUPPORTED ) >= 0;
     }
 
     public boolean isConstructorSupported() {
-        return constructorSupported;
+        return compareTo( CONSTRUCTOR_SUPPORTED ) >= 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+        MapStructVersion that = (MapStructVersion) o;
+        return major == that.major && minor == that.minor && patch == that.patch &&
+                releaseStateVersion == that.releaseStateVersion && releaseState == that.releaseState;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash( major, minor, patch, releaseState, releaseStateVersion );
     }
 }

--- a/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
@@ -11,12 +11,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.jar.Attributes;
 import java.util.stream.Stream;
 import javax.swing.Icon;
 
 import com.intellij.codeInsight.AnnotationUtil;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.java.library.JavaLibraryUtil;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.roots.ProjectRootManager;
@@ -106,6 +108,7 @@ public class MapstructUtil {
     private static final String ENUM_MAPPING_ANNOTATION_FQN = EnumMapping.class.getName();
     private static final String IMMUTABLE_FQN = "org.immutables.value.Value.Immutable";
     private static final String FREE_BUILDER_FQN = "org.inferred.freebuilder.FreeBuilder";
+    public static final Attributes.Name VERSION_ATTRIBUTE = new Attributes.Name("Bundle-Version");
 
     /**
      * Hide constructor.
@@ -563,26 +566,15 @@ public class MapstructUtil {
     public static MapStructVersion resolveMapStructProjectVersion(@NotNull PsiFile psiFile) {
         Module module = ModuleUtilCore.findModuleForFile( psiFile.getVirtualFile(), psiFile.getProject() );
         if ( module == null ) {
-            return MapStructVersion.V1_2_O;
+            return MapStructVersion.DEFAULT_VERSION;
         }
-        return CachedValuesManager.getManager( module.getProject() ).getCachedValue( module, () -> {
-            MapStructVersion mapStructVersion;
-            if ( JavaPsiFacade.getInstance( module.getProject() )
-                .findClass( ENUM_MAPPING_ANNOTATION_FQN, module.getModuleRuntimeScope( false ) ) != null ) {
-                mapStructVersion = MapStructVersion.V1_4_O;
-            }
-            else if ( JavaPsiFacade.getInstance( module.getProject() )
-                .findClass( BUILDER_ANNOTATION_FQN, module.getModuleRuntimeScope( false ) ) != null ) {
-                mapStructVersion = MapStructVersion.V1_3_O;
-            }
-            else {
-                mapStructVersion = MapStructVersion.V1_2_O;
-            }
-            return CachedValueProvider.Result.createSingleDependency(
-                mapStructVersion,
-                ProjectRootManager.getInstance( module.getProject() )
-            );
-        } );
+        return CachedValuesManager.getManager( module.getProject() ).getCachedValue( module,
+                () -> CachedValueProvider.Result.createSingleDependency(
+                        MapStructVersion.fromVersionString(
+                                JavaLibraryUtil.getLibraryVersion( module, "org.mapstruct:mapstruct",
+                                        VERSION_ATTRIBUTE ) ),
+                        ProjectRootManager.getInstance( module.getProject() )
+                ) );
     }
 
     private static boolean immutablesOnClassPath(@NotNull PsiFile psiFile) {

--- a/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
+++ b/src/main/java/org/mapstruct/intellij/util/MapstructUtil.java
@@ -52,9 +52,7 @@ import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mapstruct.BeanMapping;
-import org.mapstruct.Builder;
 import org.mapstruct.Context;
-import org.mapstruct.EnumMapping;
 import org.mapstruct.InheritConfiguration;
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
@@ -104,8 +102,6 @@ public class MapstructUtil {
     static final String VALUE_MAPPINGS_ANNOTATION_FQN = ValueMappings.class.getName();
     private static final String MAPPING_TARGET_ANNOTATION_FQN = MappingTarget.class.getName();
     private static final String CONTEXT_ANNOTATION_FQN = Context.class.getName();
-    private static final String BUILDER_ANNOTATION_FQN = Builder.class.getName();
-    private static final String ENUM_MAPPING_ANNOTATION_FQN = EnumMapping.class.getName();
     private static final String IMMUTABLE_FQN = "org.immutables.value.Value.Immutable";
     private static final String FREE_BUILDER_FQN = "org.inferred.freebuilder.FreeBuilder";
     public static final Attributes.Name VERSION_ATTRIBUTE = new Attributes.Name("Bundle-Version");

--- a/src/test/java/org/mapstruct/intellij/MapstructBaseCompletionTestCase.java
+++ b/src/test/java/org/mapstruct/intellij/MapstructBaseCompletionTestCase.java
@@ -6,9 +6,12 @@
 package org.mapstruct.intellij;
 
 import com.intellij.codeInsight.completion.LightFixtureCompletionTestCase;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.DependencyScope;
-import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.pom.java.LanguageLevel;
 import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.fixtures.MavenDependencyUtil;
 import org.jetbrains.annotations.NotNull;
@@ -20,14 +23,15 @@ import org.jetbrains.annotations.NotNull;
  */
 public abstract class MapstructBaseCompletionTestCase extends LightFixtureCompletionTestCase {
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        ModuleRootModificationUtil.updateModel( getModule(), model -> {
+    public static final LightProjectDescriptor WITH_MAPSTRUCT_JAVA17 = new ProjectDescriptor(LanguageLevel.JDK_17) {
+        @Override
+        public void configureModule(@NotNull Module module, @NotNull ModifiableRootModel model,
+                                    @NotNull ContentEntry contentEntry) {
+            super.configureModule(module, model, contentEntry);
             MavenDependencyUtil.addFromMaven( model, "org.mapstruct:mapstruct:1.5.3.Final",
                     false, DependencyScope.PROVIDED );
-        } );
-    }
+        }
+    };
 
     protected void addDirectoryToProject(@NotNull String directory) {
         myFixture.copyDirectoryToProject( directory, StringUtil.getShortName( directory, '/' ) );
@@ -36,6 +40,6 @@ public abstract class MapstructBaseCompletionTestCase extends LightFixtureComple
     @NotNull
     @Override
     protected LightProjectDescriptor getProjectDescriptor() {
-        return JAVA_17;
+        return WITH_MAPSTRUCT_JAVA17;
     }
 }

--- a/src/test/java/org/mapstruct/intellij/MapstructBaseCompletionTestCase.java
+++ b/src/test/java/org/mapstruct/intellij/MapstructBaseCompletionTestCase.java
@@ -27,7 +27,7 @@ public abstract class MapstructBaseCompletionTestCase extends LightFixtureComple
         @Override
         public void configureModule(@NotNull Module module, @NotNull ModifiableRootModel model,
                                     @NotNull ContentEntry contentEntry) {
-            super.configureModule(module, model, contentEntry);
+            super.configureModule( module, model, contentEntry );
             MavenDependencyUtil.addFromMaven( model, "org.mapstruct:mapstruct:1.5.3.Final",
                     false, DependencyScope.PROVIDED );
         }

--- a/src/test/java/org/mapstruct/intellij/MapstructBaseCompletionTestCase.java
+++ b/src/test/java/org/mapstruct/intellij/MapstructBaseCompletionTestCase.java
@@ -5,14 +5,12 @@
  */
 package org.mapstruct.intellij;
 
-import java.io.File;
-
 import com.intellij.codeInsight.completion.LightFixtureCompletionTestCase;
+import com.intellij.openapi.roots.DependencyScope;
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess;
 import com.intellij.testFramework.LightProjectDescriptor;
-import com.intellij.testFramework.PsiTestUtil;
-import com.intellij.util.PathUtil;
+import com.intellij.testFramework.fixtures.MavenDependencyUtil;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -22,21 +20,13 @@ import org.jetbrains.annotations.NotNull;
  */
 public abstract class MapstructBaseCompletionTestCase extends LightFixtureCompletionTestCase {
 
-    private static final String BUILD_LIBS_DIRECTORY = "build/libs";
-
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        final String mapstructLibPath = PathUtil.toSystemIndependentName( new File( BUILD_LIBS_DIRECTORY )
-            .getAbsolutePath() );
-        VfsRootAccess.allowRootAccess( getTestRootDisposable(), mapstructLibPath );
-        PsiTestUtil.addLibrary(
-            myFixture.getProjectDisposable(),
-            myFixture.getModule(),
-            "Mapstruct",
-            mapstructLibPath,
-            "mapstruct.jar"
-        );
+        ModuleRootModificationUtil.updateModel( getModule(), model -> {
+            MavenDependencyUtil.addFromMaven( model, "org.mapstruct:mapstruct:1.5.3.Final",
+                    false, DependencyScope.PROVIDED );
+        } );
     }
 
     protected void addDirectoryToProject(@NotNull String directory) {

--- a/src/test/java/org/mapstruct/intellij/inspection/UnmappedImmutablesFromTargetPropertiesInspectionTest.java
+++ b/src/test/java/org/mapstruct/intellij/inspection/UnmappedImmutablesFromTargetPropertiesInspectionTest.java
@@ -5,12 +5,12 @@
  */
 package org.mapstruct.intellij.inspection;
 
-import java.io.File;
 import java.util.List;
 
 import com.intellij.codeInsight.intention.IntentionAction;
-import com.intellij.testFramework.PsiTestUtil;
-import com.intellij.util.PathUtil;
+import com.intellij.openapi.roots.DependencyScope;
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.testFramework.fixtures.MavenDependencyUtil;
 import org.jetbrains.annotations.NotNull;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,8 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Stephan Leicht Vogt
  */
 public class UnmappedImmutablesFromTargetPropertiesInspectionTest extends BaseInspectionTest {
-
-    private static final String BUILD_TEST_LIBS_DIRECTORY = "build/test-libs";
 
     @NotNull
     @Override
@@ -31,16 +29,10 @@ public class UnmappedImmutablesFromTargetPropertiesInspectionTest extends BaseIn
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        String immutablesLibPath = PathUtil.toSystemIndependentName(
-            new File( BUILD_TEST_LIBS_DIRECTORY ).getAbsolutePath()
-        );
-        PsiTestUtil.addLibrary(
-            myFixture.getProjectDisposable(),
-            myFixture.getModule(),
-            "Immutables",
-            immutablesLibPath,
-            "immutables.jar"
-        );
+        ModuleRootModificationUtil.updateModel( getModule(), model -> {
+            MavenDependencyUtil.addFromMaven( model, "org.immutables:value:2.10.1", false, DependencyScope.PROVIDED );
+        } );
+
         myFixture.copyFileToProject(
             "UnmappedImmutablesFromTargetPropertiesData.java",
             "org/example/data/UnmappedImmutablesFromTargetPropertiesData.java"


### PR DESCRIPTION
I replace the existing version check logic with `JavaLibraryUtil.getLibraryVersion`.

In addition I replaced the custom psi `addLibrary` with `addFromMaven`.